### PR TITLE
MirageOS support (Unix only)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,7 @@
 [submodule "src/vendor/h2"]
 	path = src/vendor/h2
 	url = https://github.com/aantron/ocaml-h2.git
+[submodule "src/vendor/paf"]
+	path = src/vendor/paf
+	url = https://github.com/dinosaure/paf-le-chien
+	branch = sync-with-dream

--- a/dream.opam
+++ b/dream.opam
@@ -13,7 +13,7 @@ dev-repo: "git+https://github.com/aantron/dream.git"
 
 build: [
   ["dune" "build" "-p"
-    "dream,gluten,gluten-lwt,gluten-lwt-unix,websocketaf,httpaf,httpaf-lwt,httpaf-lwt-unix,hpack,h2,h2-lwt,h2-lwt-unix"
+    "dream,gluten,gluten-lwt,gluten-lwt-unix,websocketaf,httpaf,httpaf-lwt,httpaf-lwt-unix,hpack,h2,h2-lwt,h2-lwt-unix,paf"
     "-j" jobs]
 ]
 
@@ -31,6 +31,7 @@ install: [
   ["opam-installer" "--prefix" prefix "src/vendor/h2/h2.install"]
   ["opam-installer" "--prefix" prefix "src/vendor/h2/h2-lwt.install"]
   ["opam-installer" "--prefix" prefix "src/vendor/h2/h2-lwt-unix.install"]
+  ["opam-installer" "--prefix" prefix "src/vendor/paf/paf.install"]
 ]
 # TODO Set all these packages as conflicts.
 # TODO Use dune install -p ...
@@ -69,6 +70,7 @@ depends: [
   # "gluten-lwt-unix"
   # "httpaf"
   # "httpaf-lwt-unix"
+  # "paf"
 
   # Dependencies of vendored packages.
   "angstrom" {>= "0.14.0"}

--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,5 @@
 (lang dune 2.7)
-(implicit_transitive_deps false)
+(implicit_transitive_deps true)
 
 ; TODO LATER
 ; Note: implicit_transitive_deps is useful during massive development, but is

--- a/example/x-mirage/_tags
+++ b/example/x-mirage/_tags
@@ -1,0 +1,1 @@
+true: package(digestif.c)

--- a/example/x-mirage/config.ml
+++ b/example/x-mirage/config.ml
@@ -1,0 +1,13 @@
+open Mirage
+
+let port =
+  let doc = Key.Arg.info ~doc:"port of HTTP service." [ "p"; "port" ] in
+  Key.(create "port" Arg.(opt (some int) None doc))
+
+let dream =
+  foreign "Unikernel.Make"
+    ~keys:[ Key.abstract port ]
+    ~packages:[ package "dream" ~sublibs:[ "mirage" ] ]
+    (time @-> stackv4v6 @-> job)
+
+let () = register "dream" [ dream $ default_time $ generic_stackv4v6 default_network ]

--- a/example/x-mirage/unikernel.ml
+++ b/example/x-mirage/unikernel.ml
@@ -5,8 +5,13 @@ module Make (Time : Mirage_time.S) (Stack : Mirage_stack.V4V6) = struct
 
   let dream _ = Dream.respond "Hello World!"
 
+  let builtin =
+    Dream.pipeline
+      [ Dream.content_length
+      ; Dream.assign_request_id ]
+
   let start _ stack =
-    let service = HTTP.service None dream in
+    let service = HTTP.service None (builtin dream) in
     HTTP.init ~port:8080 stack >>= fun t ->
     let `Initialized th = HTTP.serve service t in th
 end

--- a/example/x-mirage/unikernel.ml
+++ b/example/x-mirage/unikernel.ml
@@ -1,0 +1,12 @@
+open Lwt.Infix
+
+module Make (Time : Mirage_time.S) (Stack : Mirage_stack.V4V6) = struct
+  module HTTP = Dream.Make (Time) (Stack)
+
+  let dream _ = Dream.respond "Hello World!"
+
+  let start _ stack =
+    let service = HTTP.service None dream in
+    HTTP.init ~port:8080 stack >>= fun t ->
+    let `Initialized th = HTTP.serve service t in th
+end

--- a/src/dream.mli
+++ b/src/dream.mli
@@ -2032,3 +2032,15 @@ val sort_headers : (string * string) list -> (string * string) list
 
 val echo : handler
 (** Responds with the request body. *)
+
+module Make
+  (Time : Mirage_time.S)
+  (Stack : Mirage_stack.V4V6) : sig
+  type stack = Stack.t
+  type t
+
+  val init : port:int -> stack -> t Lwt.t
+  val service : Tls.Config.server option -> handler -> t Paf.service
+  val serve :
+    ?stop:Lwt_switch.t -> 't Paf.service -> 't -> [ `Initialized of unit Lwt.t ]
+end

--- a/src/dune
+++ b/src/dune
@@ -9,6 +9,7 @@
   dream.middleware
   dream.pure
   dream.sql
+  dream.mirage
   graphql-lwt
   logs
   lwt

--- a/src/mirage/dream__mirage.ml
+++ b/src/mirage/dream__mirage.ml
@@ -1,0 +1,148 @@
+open Lwt.Infix
+
+module Dream = Dream__pure.Inmost
+module Error = Dream__middleware.Error
+
+let to_dream_method method_ =
+  Httpaf.Method.to_string method_ |> Dream.string_to_method
+
+let to_httpaf_status status =
+  Dream.status_to_int status |> Httpaf.Status.of_code
+
+let to_h2_status status =
+  Dream.status_to_int status |> H2.Status.of_code
+
+let forward_body_general (response : Dream.response)
+  (write_string : ?off:int -> ?len:int -> string -> unit)
+  (write_bigstring : ?off:int -> ?len:int -> Dream.bigstring -> unit)
+  http_flush close =
+  let rec send () =
+    response
+    |> Dream.next
+      ~bigstring
+      ~string
+      ~flush
+      ~close
+      ~exn:ignore
+  and bigstring chunk off len =
+    write_bigstring ~off ~len chunk;
+    send ()
+  and string chunk off len =
+    write_string ~off ~len chunk;
+    send ()
+  and flush () =
+    http_flush send
+  in
+  send ()
+
+let forward_body
+    (response : Dream.response)
+    (body : [ `write ] Httpaf.Body.t) =
+  forward_body_general
+    response
+    (Httpaf.Body.write_string body)
+    (Httpaf.Body.write_bigstring body)
+    (Httpaf.Body.flush body)
+    (fun () -> Httpaf.Body.close_writer body)
+
+let with_httpaf app _user's_error_handler user's_dream_handler =
+  let request_handler (edn : string) (reqd : Httpaf.Reqd.t) =
+    Dream__middleware.Log.set_up_exception_hook () ;
+    let request = Httpaf.Reqd.request reqd in
+    let client  = edn in
+    let method_ = to_dream_method request.meth in
+    let target  = request.target in
+    let version = request.version.major, request.version.minor in
+    let headers = Httpaf.Headers.to_list request.headers in
+    let body    = Httpaf.Reqd.request_body reqd in
+    let request : Dream.request = Dream.request_from_http ~app ~client ~method_ ~target ~version ~headers in
+    Lwt.async begin fun () ->
+      Dream.flush request >>= fun () ->
+      let on_eof () = Dream.close_stream request |> ignore in
+      let rec loop () =
+        Httpaf.Body.schedule_read
+          body
+          ~on_eof
+          ~on_read:(fun buffer ~off ~len ->
+            Lwt.on_success
+              (Dream__pure.Body.write_bigstring buffer off len request.body)
+              loop) in
+      loop () ; Lwt.return_unit end ;
+    Lwt.async begin fun () ->
+      Lwt.catch begin fun () ->
+        user's_dream_handler request >>= fun response ->
+        let forward_response response =
+          let headers = Httpaf.Headers.of_list (Dream.all_headers response) in
+          let status  = to_httpaf_status (Dream.status response) in
+          let httpaf_response = Httpaf.Response.create ~headers status in
+          let body    = Httpaf.Reqd.respond_with_streaming reqd httpaf_response in
+          forward_body response body ;
+          Lwt.return_unit in
+        match Dream.is_websocket response with
+        | None -> forward_response response
+        | Some _user's_websocket_handler -> assert false (* TODO *)
+      end @@ fun exn ->
+        Httpaf.Reqd.report_exn reqd exn ;
+        Lwt.return_unit
+    end in
+  request_handler
+
+let forward_body_h2
+    (response : Dream.response)
+    (body : [ `write ] H2.Body.t) =
+  forward_body_general
+    response
+    (H2.Body.write_string body)
+    (H2.Body.write_bigstring body)
+    (H2.Body.flush body)
+    (fun () -> H2.Body.close_writer body)
+
+let with_h2 app _user's_error_handler user's_dream_handler =
+  let request_handler edn reqd =
+    Dream__middleware.Log.set_up_exception_hook () ;
+    let request = H2.Reqd.request reqd in
+    let client  = edn in
+    let method_ = to_dream_method request.meth in
+    let target  = request.target in
+    let version = (2, 0) in
+    let headers = H2.Headers.to_list request.headers in
+    let body    = H2.Reqd.request_body reqd in
+    let request : Dream.request = Dream.request_from_http ~app ~client ~method_ ~target ~version ~headers in
+    Lwt.async begin fun () ->
+      Dream.flush request >>= fun () ->
+      let on_eof () = Dream.close_stream request |> ignore in
+      let rec loop () =
+        H2.Body.schedule_read
+          body
+          ~on_eof
+          ~on_read:(fun buffer ~off ~len ->
+            Dream__pure.Body.write_bigstring buffer off len request.body
+            |> ignore ;
+            loop ()) in
+      loop () ; Lwt.return_unit end ;
+    Lwt.async begin fun () ->
+      Lwt.catch begin fun () ->
+        user's_dream_handler request >>= fun response ->
+        let forward_response response =
+          let headers = H2.Headers.of_list (Dream.all_headers response) in
+          let status = to_h2_status (Dream.status response) in
+          let h2_response = H2.Response.create ~headers status in
+          let body = H2.Reqd.respond_with_streaming reqd h2_response in
+          forward_body_h2 response body ;
+          Lwt.return_unit in
+        match Dream.is_websocket response with
+        | None -> forward_response response
+        | Some _user's_websocket_handler -> assert false (* TODO *)
+      end @@ fun exn ->
+        H2.Reqd.report_exn reqd exn ;
+        Lwt.return_unit
+    end in
+  request_handler
+
+let service (app, user's_dream_handler) info accept close =
+  let request_handler edn : [ `write ] Alpn.reqd_handler -> unit = function
+    | Alpn.Reqd_handler (HTTP_1_0, reqd) -> with_httpaf app () user's_dream_handler edn reqd
+    | Alpn.Reqd_handler (HTTP_1_1, reqd) -> with_httpaf app () user's_dream_handler edn reqd
+    | Alpn.Reqd_handler (HTTP_2_0, reqd) -> with_h2 app () user's_dream_handler edn reqd in
+  let error_handler _edn ?request:_ _error _response = () (* TODO *) in
+  Alpn.serve info ~error_handler ~request_handler accept close

--- a/src/mirage/dream__mirage.mli
+++ b/src/mirage/dream__mirage.mli
@@ -1,0 +1,8 @@
+module Dream = Dream__pure.Inmost
+
+val service :
+     (Dream.app * Dream.handler)
+  -> 'flow Alpn.info
+  -> ('t -> ('flow, ([> `Closed | `Msg of string ] as 'error)) result Lwt.t)
+  -> ('t -> unit Lwt.t)
+  -> 't Paf.service

--- a/src/mirage/dune
+++ b/src/mirage/dune
@@ -1,0 +1,4 @@
+(library
+ (public_name dream.mirage)
+ (name dream__mirage)
+ (libraries bigarray-compat bigstringaf lwt dream.pure dream.middleware paf.alpn paf.mirage))


### PR DESCRIPTION
This is a first shot to support MirageOS with [paf](https://github.com/dinosaure/paf-le-chien). I would like to explain the difficulty for MirageOS to support this framework, our vision about the abstraction and an explanation about what I did on this PR.

In the spirit of MirageOS, we need to be aware that we don't have:
- a file-system
- a concrete socket
- anything related to a _syscall_

This means above all that our projects must be thought of as interchangeable software bricks depending on the target (from the CPU architecture, the available devices, to the application desired by the user). This is why all our MirageOS projects often work ... everywhere!

However, to make them work specifically for your case, for your application, you often need a little bit of glue. This is done by applying a _functor_, specializing a function, choosing an implementation at the link stage. But a MirageOS project will never go beyond the barrier between what is the implementation of a format, a protocol, the core, etc. and a real and usable example. And if we really need to cross that barrier, it would be by an explicitly separate derivation of the core (confers `*-lwt-unix`, `*-async`, etc.).

Anyway, the point is that the desire to have a _first-entry point_ within `dream` that can run an HTTP server is beyond this barrier. So to speak, the project as it stands is not, by design, compatible with MirageOS. Since the end user would have to use the `Dream` module, it would inevitably come with `Dream.run`. Even if the latter wanted to use MirageOS support (which is a functor), Dream.run would continue to exist in the final object - and would not be able to compile for targets like Solo5 or Xen.

Second, Dream uses dependencies that transitively bring `unix` and `lwt.unix`. Or it uses dependencies that bring C dependencies that may be incompatible (like `cryptokit`). Indeed, in the spirit of MirageOS, we try to remove as much C as possible. This work is necessary because we do not integrate a standard C library! However, MirageOS does allow compiling projects for Unix. In this case (and this is the example given here), Dream works.

Finally, this is mainly about HTTP. Considering everything I just said, it can be difficult to solve this gap between a TCP/IP stack given afterwards and TLS + ALPN while remaining compatible with MirageOS. This is where mimic comes in. We can consider this socket as the only one that is concrete (no _functor_ needed) and compatible with MirageOS. In fact, the resolution of what `Mimic.flow` represents is done dynamically - you can see a tutorial about it [here](https://mirage.github.io/ocaml-git/mimic/index.html).

Thanks to Mimic, we can start to process the information and especially ALPN with `ocaml-tls` (which is compatible with MirageOS). This is what I started doing for [`paf`](https://github.com/dinosaure/paf-le-chien/pull/20) which is just an extension of Mimic to the special case of HTTP. The latter supports HTTP/1.1 with `http/af` and H2 with `h2`.

At this point we are still compatible with MirageOS. This means that we are compatible with all contexts _a priori_. Indeed, using the _functor_ with `tcpip.stack-socket` derives [`serve`](https://github.com/aantron/dream/compare/master...dinosaure:mirage?expand=1#diff-99cba5533ea54eb494c60de86fe54539e9a458231fd90d68080dd02c3390a8d0R2044) to be usable in a simple executable - again, in our way of doing things, we won't go beyond that barrier. A bit more abstract, [`dream.mirage`](https://github.com/aantron/dream/compare/master...dinosaure:mirage?expand=1#diff-56a604a5241790aa4d845f9055ef47a8641756f3cbbf534a6894f1177d8ea6c5) expects only 4 system specific things plus a `Dream.app` and the `Dream.handler`:
- the accept function
- the close function
- the injection of the _flow_ into a Mimic.flow (for this you have to read the tutorial)
- the projection of some value from the flow (ALPN, peer)

So it is possible to derive a `unix` support directly from these 4 informations and directly use a `Lwt_unix.file_descr` if you want. Again, in the spirit of MirageOS, we don't want to go beyond this barrier.

So we have something that works for MirageOS and only for `unix`. This is a first step :) . You can try MirageOS by going to `example/x-mirage` and:
```
$ mirage configure -t unix
$ make depends
$ mirage build
$ ./main.native
```

From the discussion with @aantron. Theoretically Dream can be compatible with MirageOS and we can imagine a complete system with it. This PR is the first step. However, there are still a few steps to go before we have a DreamOS 🙂 !