### PR TITLE
Mention Spin to create new projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,16 @@ include their own build commands. They don't have to be subdirectories of
 Especially consider starting with the [full-stack examples][fullstack], which
 build both a Dream server and a JavaScript client.
 
+### Project template
+
+To quickly start a new project with [Spin](https://github.com/tmattio/spin), you can use:
+
+```bash
+opam spin new https://github.com/ocaml-templates/spin-dream.git
+```
+
+The project contains a typical project structure for a real-world application, as well as optional configurations for TailwindCSS and Turbolink. You can read more about it [here](https://github.com/tmattio/spin-dream/#readme)
+
 ### opam
 
 ```


### PR DESCRIPTION
This PR recommends Spin to create new Dream projects in the Quickstart section.

I've put the mention of Spin higher than the quickstart script, but of course, I'm happy to change that if you feel the middleware example is a better entry point for new users.

I'm creating the PR as draft as there are a few things I'd like to add to the template before it is recommended. Namely, making the setup of TailwindCSS and Turbolink optional, and adding some boilerplate examples with Caqti.