### PR TITLE
Add esy dependencies to enable VSCode intellisense

### DIFF
--- a/example/2-middleware/esy.json
+++ b/example/2-middleware/esy.json
@@ -2,10 +2,12 @@
   "dependencies": {
     "@opam/dream": "1.0.0~alpha2",
     "@opam/dune": "^2.0",
+    "ocaml": "4.12.x"
+  },
+  "devDependencies": {
     // The OCaml Platform for VSCode require ocaml-lsp-server and ocamlfind-secondary to enable intellisense.
     "@opam/ocaml-lsp-server": "*",
-    "@opam/ocamlfind-secondary": "*",
-    "ocaml": "4.12.x"
+    "@opam/ocamlfind-secondary": "*"
   },
   "resolutions": {
     "@opam/conf-libev": "esy-packages/libev:package.json#0b5eb6685b688649045aceac55dc559f6f21b829"

--- a/example/2-middleware/esy.json
+++ b/example/2-middleware/esy.json
@@ -2,6 +2,9 @@
   "dependencies": {
     "@opam/dream": "1.0.0~alpha2",
     "@opam/dune": "^2.0",
+    // The OCaml Platform for VSCode require ocaml-lsp-server and ocamlfind-secondary to enable intellisense.
+    "@opam/ocaml-lsp-server": "*",
+    "@opam/ocamlfind-secondary": "*",
     "ocaml": "4.12.x"
   },
   "resolutions": {


### PR DESCRIPTION
## Changes

Added the necessary dependencies to enable VSCode intellisense for example 2-middleware. 

## Notes

* In addition to installing these dependencies, must open each example in their own VSCode root project. 
* To use `./quickstart`, Mac users must run `chmod +x ./quickstart` to be able to run the startup script. 

@aantron I believe you should add the two bulletpoints somewhere to help beginners onboard as well. 

Hope this PR helps ya, if not actual merge, at least for some user feedback 😆 