### PR TITLE
Remove double slashes from sqlite3 example

### DIFF
--- a/src/dream.mli
+++ b/src/dream.mli
@@ -1581,7 +1581,7 @@ val sql : request -> (Caqti_lwt.connection -> 'a promise) -> 'a promise
     {[
       let () =
         Dream.run
-        @@ Dream.sql_pool "sqlite3://db.sqlite"
+        @@ Dream.sql_pool "sqlite3:db.sqlite"
         @@ fun request ->
           Dream.sql request (fun db ->
             (* ... *) |> Dream.html)


### PR DESCRIPTION
Without it, it throws `Sqlite URI cannot contain user or host components`