### PR TITLE
Use `ptime` instead of `Unix` to compute the date (MirageOS support).

### DIFF
--- a/dream.opam
+++ b/dream.opam
@@ -71,6 +71,7 @@ depends: [
   "ssl" {>= "0.5.8"}  # Ssl.get_negotiated_alpn_protocol.
   "uri" {>= "4.2.0"}
   "yojson"  # ...
+  "ptime"  # time and date
 
   # Currently vendored.
   # "gluten"

--- a/dream.opam
+++ b/dream.opam
@@ -71,7 +71,7 @@ depends: [
   "ssl" {>= "0.5.8"}  # Ssl.get_negotiated_alpn_protocol.
   "uri" {>= "4.2.0"}
   "yojson"  # ...
-  "ptime"  # time and date
+  "ptime" {>= "0.8.1"} # time and date
 
   # Currently vendored.
   # "gluten"

--- a/src/pure/dune
+++ b/src/pure/dune
@@ -7,8 +7,8 @@
   multipart_form
   hmap
   lwt
-  lwt.unix
   uri
+  ptime
  )
  (preprocess (pps lwt_ppx))
  (instrumentation (backend bisect_ppx)))

--- a/src/pure/formats.ml
+++ b/src/pure/formats.ml
@@ -64,9 +64,9 @@ let to_set_cookie
       let ((y, m, d), ((hh, mm, ss), _tz_offset_s)) = Ptime.to_date_time time in
       let month =
         match m with
-        | 0 -> "Jan" | 1 -> "Feb" | 2 -> "Mar" | 3 -> "Apr" | 4 -> "May"
-        | 5 -> "Jun" | 6 -> "Jul" | 7 -> "Aug" | 8 -> "Sep" | 9 -> "Oct"
-        | 10 -> "Nov" | 11 -> "Dec"
+        | 1 -> "Jan" | 2 -> "Feb" | 3 -> "Mar" | 4 -> "Apr" | 5 -> "May"
+        | 6 -> "Jun" | 7 -> "Jul" | 8 -> "Aug" | 9 -> "Sep" | 10 -> "Oct"
+        | 11 -> "Nov" | 12 -> "Dec"
         | _ -> assert false
       in
       (* [Ptime.to_date_time] docs give range 0..60 for [ss], accounting for leap


### PR DESCRIPTION
This PR wants to delete the Unix dependency from the core of `dream`. It replaces `Unix.gmtime` by [ptime](https://github.com/dbuenzli/ptime) which is compatible with MirageOS (no `unix` _syscall_). It seems that both are the same so nothing seems to change.

I took the opportunity to delete `lwt.unix` as a dependency of `dream.pure` to be sure to avoid the `unix.cmxa` library at the link time.