### PR TITLE
Delete any occurrences of Unix.gettimeofday to be compatible with MirageOS

### DIFF
--- a/dream.opam
+++ b/dream.opam
@@ -72,6 +72,7 @@ depends: [
   "uri" {>= "4.2.0"}
   "yojson"  # ...
   "ptime" {>= "0.8.1"} # time and date
+  "mirage-clock"
 
   # Currently vendored.
   # "gluten"

--- a/dream.opam
+++ b/dream.opam
@@ -64,6 +64,7 @@ depends: [
   "lwt_ssl"
   "logs" {>= "0.5.0"}
   "magic-mime"
+  "mirage-clock"
   "mirage-crypto" {>= "0.8.1"}  # AES-256-GCM.
   "mirage-crypto-rng" {>= "0.8.0"}  # Signature of initialize.
   "multipart_form" {>= "0.3.0"}
@@ -72,7 +73,6 @@ depends: [
   "uri" {>= "4.2.0"}
   "yojson"  # ...
   "ptime" {>= "0.8.1"} # time and date
-  "mirage-clock"
 
   # Currently vendored.
   # "gluten"

--- a/src/dream.ml
+++ b/src/dream.ml
@@ -83,8 +83,7 @@ let log =
 
 include Dream__middleware.Tag
 
-let ( <.> ) f g = fun x -> f (g x)
-let now = Ptime.to_float_s <.> Ptime.v <.> Ptime_clock.now_d_ps
+let now () = Ptime.to_float_s (Ptime.v (Ptime_clock.now_d_ps ()))
 
 let form = form ~now
 let multipart = multipart ~now

--- a/src/dream.ml
+++ b/src/dream.ml
@@ -19,12 +19,10 @@ let next ~buffer ~close ~exn request =
 
 include Dream__middleware.Log
 include Dream__middleware.Log.Make (Ptime_clock)
-
 (* Initalize logs with the default reporter which uses [Ptime_clock], this
  * function is a part of [Dream__middleware.Log.Make], it's why it is not
  * prepended by a module name. *)
 let () = initialize ()
-
 include Dream__middleware.Echo
 
 let default_log =

--- a/src/dream.ml
+++ b/src/dream.ml
@@ -18,10 +18,11 @@ let next ~buffer ~close ~exn request =
   next ~buffer ~close ~exn request
 
 include Dream__middleware.Log
-include Dream__middleware.Echo
+include Dream__middleware.Log.Make (Ptime_clock)
 
-let logger =
-  Dream__middleware.Log.logger
+let () = initialize ()
+
+include Dream__middleware.Echo
 
 let default_log =
   Dream__middleware.Log.sub_log (Logs.Src.name Logs.default)
@@ -35,6 +36,7 @@ include Dream__middleware.Router
 include Dream__middleware.Static
 
 include Dream__middleware.Session
+include Dream__middleware.Session.Make (Ptime_clock)
 let sql_sessions = Dream__sql.Session.middleware
 
 include Dream__middleware.Flash_message
@@ -80,3 +82,12 @@ let log =
   Dream__middleware.Log.convenience_log
 
 include Dream__middleware.Tag
+
+let ( <.> ) f g = fun x -> f (g x)
+let now = Ptime.to_float_s <.> Ptime.v <.> Ptime_clock.now_d_ps
+
+let form = form ~now
+let multipart = multipart ~now
+let csrf_token = csrf_token ~now
+let verify_csrf_token = verify_csrf_token ~now
+let form_tag = form_tag ~now

--- a/src/dream.ml
+++ b/src/dream.ml
@@ -20,6 +20,9 @@ let next ~buffer ~close ~exn request =
 include Dream__middleware.Log
 include Dream__middleware.Log.Make (Ptime_clock)
 
+(* Initalize logs with the default reporter which uses [Ptime_clock], this
+ * function is a part of [Dream__middleware.Log.Make], it's why it is not
+ * prepended by a module name. *)
 let () = initialize ()
 
 include Dream__middleware.Echo

--- a/src/dune
+++ b/src/dune
@@ -13,4 +13,5 @@
   logs
   lwt
   lwt.unix
+  ptime.clock.os
  ))

--- a/src/middleware/csrf.ml
+++ b/src/middleware/csrf.ml
@@ -13,8 +13,8 @@ let field_name =
 let default_valid_for =
   60. *. 60.
 
-let csrf_token ?(valid_for = default_valid_for) request =
-  let now = Unix.gettimeofday () in
+let csrf_token ~now ?(valid_for = default_valid_for) request =
+  let now = now () in
 
   `Assoc [
     "session", `String (Session.session_label request);
@@ -34,7 +34,7 @@ type csrf_result = [
   | `Invalid
 ]
 
-let verify_csrf_token request token = Lwt.return @@
+let verify_csrf_token ~now request token = Lwt.return @@
   match Dream__pure.Formats.from_base64url token with
   | None ->
     log.warning (fun log -> log ~request "CSRF token not Base64-encoded");
@@ -67,7 +67,7 @@ let verify_csrf_token request token = Lwt.return @@
       `Wrong_session
     end
     else
-      let now = Unix.gettimeofday () in
+      let now = now () in
       if expires_at > now then
         `Ok
       else begin

--- a/src/middleware/dune
+++ b/src/middleware/dune
@@ -5,9 +5,9 @@
   digestif
   dream.cipher
   dream.pure
+  mirage-clock
   multipart_form
   multipart_form.lwt
-  mirage-clock
   ptime
   unstrctrd
   fmt

--- a/src/middleware/dune
+++ b/src/middleware/dune
@@ -5,16 +5,16 @@
   digestif
   dream.cipher
   dream.pure
-  mirage-clock
   multipart_form
   multipart_form.lwt
-  ptime
   unstrctrd
   fmt
   fmt.tty
   logs
   lwt
   magic-mime
+  mirage-clock
+  ptime
   uri
   yojson
  )

--- a/src/middleware/dune
+++ b/src/middleware/dune
@@ -7,12 +7,13 @@
   dream.pure
   multipart_form
   multipart_form.lwt
+  mirage-clock
+  ptime
   unstrctrd
   fmt
   fmt.tty
   logs
   lwt
-  lwt.unix
   magic-mime
   uri
   yojson

--- a/src/middleware/log.ml
+++ b/src/middleware/log.ml
@@ -109,7 +109,7 @@ let reporter ~now () =
 
       (* Format the current local time. For the millisecond fraction, be careful
          of rounding 999.5+ to 1000 on output. *)
-      let time ~now =
+      let time =
         let unix_time =
           now () in
         let time = Option.get (Ptime.of_float_s unix_time) in
@@ -185,7 +185,7 @@ let reporter ~now () =
       (* The formatting proper. *)
       Format.kfprintf write formatter
         ("%a %a%s %a%a @[" ^^ format_and_arguments ^^ "@]@.")
-        Fmt.(styled `Faint string) (time ~now)
+        Fmt.(styled `Faint string) time
         Fmt.(styled `White string) source_prefix source
         Fmt.(styled level_style string) level
         Fmt.(styled request_style (styled `Italic string)) request_id

--- a/src/middleware/log.ml
+++ b/src/middleware/log.ml
@@ -194,6 +194,7 @@ let reporter ~now () =
   {Logs.report}
 
 
+
 (* Lazy initialization upon first use or call to initialize. *)
 let enable =
   ref true
@@ -454,9 +455,9 @@ let logger next_handler request =
       |> iter_backtrace (fun line -> log.warning (fun log -> log "%s" line));
 
       Lwt.fail exn)
-
-
 end
+
+
 
 (* TODO DOC Include logging itself in the timing. Or? Isn't that pointless?
    End-to -end timing should include the HTTP parser as well. The logger

--- a/src/middleware/log.ml
+++ b/src/middleware/log.ml
@@ -351,8 +351,7 @@ let initialize_log
   ()
 
 module Make (Pclock : Mirage_clock.PCLOCK) = struct
-  let ( <.> ) f g = fun x -> f (g x)
-  let now = Ptime.to_float_s <.> Ptime.v <.> Pclock.now_d_ps
+  let now () = Ptime.to_float_s (Ptime.v (Pclock.now_d_ps ()))
 
   let initializer_ = lazy begin
     if !enable then begin

--- a/src/middleware/session.ml
+++ b/src/middleware/session.ml
@@ -334,7 +334,7 @@ module Make (Pclock : Mirage_clock.PCLOCK) = struct
 
   let memory_sessions ?(lifetime = two_weeks) =
     middleware (Memory.back_end ~now lifetime)
-  
+
   let cookie_sessions ?(lifetime = two_weeks) =
     middleware (Cookie.back_end ~now lifetime)
 end

--- a/src/middleware/session.ml
+++ b/src/middleware/session.ml
@@ -330,8 +330,7 @@ let two_weeks =
   60. *. 60. *. 24. *. 7. *. 2.
 
 module Make (Pclock : Mirage_clock.PCLOCK) = struct
-  let ( <.> ) f g = fun x -> f (g x)
-  let now = Ptime.to_float_s <.> Ptime.v <.> Pclock.now_d_ps
+  let now () = Ptime.to_float_s (Ptime.v (Pclock.now_d_ps ()))
 
   let memory_sessions ?(lifetime = two_weeks) =
     middleware (Memory.back_end ~now lifetime)

--- a/src/middleware/session.ml
+++ b/src/middleware/session.ml
@@ -133,24 +133,24 @@ struct
     |> fun dictionary -> session.payload <- dictionary;
     Lwt.return_unit
 
-  let invalidate hash_table lifetime operations session =
+  let invalidate hash_table ~now lifetime operations session =
     Hashtbl.remove hash_table !session.id;
-    session := create hash_table (Unix.gettimeofday () +. lifetime);
+    session := create hash_table (now () +. lifetime);
     operations.dirty <- true;
     Lwt.return_unit
 
-  let operations hash_table lifetime session dirty =
+  let operations ~now hash_table lifetime session dirty =
     let rec operations = {
       put =
         (fun name value -> put !session name value);
       invalidate =
-        (fun () -> invalidate hash_table lifetime operations session);
+        (fun () -> invalidate ~now hash_table lifetime operations session);
       dirty;
     } in
     operations
 
-  let load hash_table lifetime request =
-    let now = Unix.gettimeofday () in
+  let load ~now:gettimeofday hash_table lifetime request =
+    let now = gettimeofday () in
 
     let valid_session =
       Dream.cookie ~decrypt:false session_cookie request
@@ -179,23 +179,23 @@ struct
     in
 
     let session = ref session in
-    Lwt.return (operations hash_table lifetime session dirty, session)
+    Lwt.return (operations ~now:gettimeofday hash_table lifetime session dirty, session)
 
-  let send (operations, session) request response =
+  let send ~now (operations, session) request response =
     if not operations.dirty then
       Lwt.return response
     else
       let id = version_session_id !session.id in
-      let max_age = !session.expires_at -. Unix.gettimeofday () in
+      let max_age = !session.expires_at -. now () in
       Lwt.return
         (Dream.set_cookie
           session_cookie id request response ~encrypt:false ~max_age)
 
-  let back_end lifetime =
+  let back_end ~now lifetime =
     let hash_table = Hashtbl.create 256 in
     {
-      load = load hash_table lifetime;
-      send;
+      load = load ~now hash_table lifetime;
+      send = send ~now;
     }
 end
 
@@ -223,21 +223,21 @@ struct
     operations.dirty <- true;
     Lwt.return_unit
 
-  let invalidate lifetime operations session =
-    session := create (Unix.gettimeofday () +. lifetime);
+  let invalidate ~now lifetime operations session =
+    session := create (now () +. lifetime);
     operations.dirty <- true;
     Lwt.return_unit
 
-  let operations lifetime session dirty =
+  let operations ~now lifetime session dirty =
     let rec operations = {
       put = (fun name value -> put operations !session name value);
-      invalidate = (fun () -> invalidate lifetime operations session);
+      invalidate = (fun () -> invalidate ~now lifetime operations session);
       dirty;
     } in
     operations
 
-  let load lifetime request =
-    let now = Unix.gettimeofday () in
+  let load ~now:gettimeofday lifetime request =
+    let now = gettimeofday () in
 
     let valid_session =
       Dream.cookie session_cookie request
@@ -291,13 +291,13 @@ struct
     in
 
     let session = ref session in
-    Lwt.return (operations lifetime session dirty, session)
+    Lwt.return (operations ~now:gettimeofday lifetime session dirty, session)
 
-  let send (operations, session) request response =
+  let send ~now (operations, session) request response =
     if not operations.dirty then
       Lwt.return response
     else
-      let max_age = !session.expires_at -. Unix.gettimeofday () in
+      let max_age = !session.expires_at -. now () in
       let value =
         `Assoc [
           "id", `String !session.id;
@@ -312,9 +312,9 @@ struct
       Lwt.return
         (Dream.set_cookie session_cookie value request response ~max_age)
 
-  let back_end lifetime = {
-    load = load lifetime;
-    send;
+  let back_end ~now lifetime = {
+    load = load ~now lifetime;
+    send = send ~now;
   }
 end
 
@@ -329,11 +329,16 @@ let {middleware; getter} =
 let two_weeks =
   60. *. 60. *. 24. *. 7. *. 2.
 
-let memory_sessions ?(lifetime = two_weeks) =
-  middleware (Memory.back_end lifetime)
+module Make (Pclock : Mirage_clock.PCLOCK) = struct
+  let ( <.> ) f g = fun x -> f (g x)
+  let now = Ptime.to_float_s <.> Ptime.v <.> Pclock.now_d_ps
 
-let cookie_sessions ?(lifetime = two_weeks) =
-  middleware (Cookie.back_end lifetime)
+  let memory_sessions ?(lifetime = two_weeks) =
+    middleware (Memory.back_end ~now lifetime)
+  
+  let cookie_sessions ?(lifetime = two_weeks) =
+    middleware (Cookie.back_end ~now lifetime)
+end
 
 let session name request =
   List.assoc_opt name (!(snd (getter request)).payload)

--- a/src/middleware/session.ml
+++ b/src/middleware/session.ml
@@ -330,13 +330,13 @@ let two_weeks =
   60. *. 60. *. 24. *. 7. *. 2.
 
 module Make (Pclock : Mirage_clock.PCLOCK) = struct
-  let now () = Ptime.to_float_s (Ptime.v (Pclock.now_d_ps ()))
+let now () = Ptime.to_float_s (Ptime.v (Pclock.now_d_ps ()))
 
-  let memory_sessions ?(lifetime = two_weeks) =
-    middleware (Memory.back_end ~now lifetime)
+let memory_sessions ?(lifetime = two_weeks) =
+  middleware (Memory.back_end ~now lifetime)
 
-  let cookie_sessions ?(lifetime = two_weeks) =
-    middleware (Cookie.back_end ~now lifetime)
+let cookie_sessions ?(lifetime = two_weeks) =
+  middleware (Cookie.back_end ~now lifetime)
 end
 
 let session name request =

--- a/src/middleware/tag.eml.ml
+++ b/src/middleware/tag.eml.ml
@@ -13,7 +13,7 @@ end
 
 (* TODO Include the path prefix. *)
 let form_tag
-    ?(method_ = `POST) ?target ?enctype ?(csrf_token = true) ~action request =
+    ~now ?(method_ = `POST) ?target ?enctype ?(csrf_token = true) ~action request =
 
   let target =
     match target with
@@ -29,6 +29,6 @@ let form_tag
     method="<%s! Dream.method_to_string method_ %>"
     action="<%s action %>"<%s! target %><%s! enctype %>>
 % if csrf_token then begin
-%   let token = Csrf.csrf_token request in
+%   let token = Csrf.csrf_token ~now request in
     <input name="<%s! Csrf.field_name %>" type="hidden" value="<%s! token %>">
 % end;

--- a/src/middleware/upload.ml
+++ b/src/middleware/upload.ml
@@ -87,7 +87,7 @@ type multipart_form =
   (string * ((string option * string) list)) list
 module Map = Map.Make (String)
 
-let multipart request =
+let multipart ~now request =
   let content_type = match Dream.header "content-type" request with
     | Some content_type ->
       Result.to_option (Multipart_form.Content_type.of_string (content_type ^ "\r\n"))
@@ -124,7 +124,7 @@ let multipart request =
           | [Some "", ""] -> name, []
           | _ -> name, List.rev values)
       in
-      Form.sort_and_check_form
+      Form.sort_and_check_form ~now
         (function
         | [None, value] -> value
         | _ -> "")


### PR DESCRIPTION
This PR wants to delete the last direct dependency to `unix` into `middlewares` to be able to use them into a MirageOS application. The only _syscall_ is `gettimeofday` and it is a bit widely used.

The main change is about the `logger` which need to be initialized. In this PR, the `logger` is initialized into the `dream.ml` module. The initialization follows what we did about `mirage-crypto` and the RNG, see specially: https://github.com/mirage/mirage-crypto/pull/64

As far as I can tell, I kept the same semantic and just delayed the way to initialize the logger and still be able to plug with MirageOS/Functoria what I really want (in that case `Mirage_clock.PCLOCK`) according to my target.

Then, some parts of some middlewares are _functorized_ over `Mirage_block.PCLOCK`, some others expects a new argument `now` which is the implementation of `gettimeofday` and we partially apply them into `dream.ml`. I don't want to systematically use _functors_ so it's why some "little" functions expects only a new `now` argument. Tell me if it's fine for you.

As far as I can tell, such update does not change the interface and only internal things and how we can compose with MirageOS at the end. Tell me what do you think about all of that and how we can improve `dream` to be agnostic to the system. Again, the hard part is about the logger and I'm not really really sure how to properly handle it.

A new dependency was added: [`Mirage_clock`](https://github.com/mirage/mirage-clock) which is a simple interface. It's not an implementation.