### PR TITLE
Delete usage of Lwt_io to be compatible with MirageOS and use `prerr_string` instead

### DIFF
--- a/src/middleware/log.ml
+++ b/src/middleware/log.ml
@@ -92,7 +92,7 @@ let reporter ~now () =
       (* Write the message. *)
       Lwt.async begin fun () ->
         Lwt.finalize
-          (fun () -> Lwt_io.(write stderr) message)
+          (fun () -> prerr_string message ; Lwt.return_unit)
           (fun () ->
             over ();
             Lwt.return_unit)


### PR DESCRIPTION
Not sure about this little PR but it wants to replace `Lwt_io.(write stderr)` by `prerr_string`. On the [`ocaml-freestanding`](https://github.com/mirage/ocaml-freestanding)/[`Solo5`](https://github.com/Solo5/solo5), we still write to the serial port 1, I believe that nothing change so.