### PR TITLE
dream.pure is MirageOS compatible

### DIFF
--- a/src/pure/inmost.ml
+++ b/src/pure/inmost.ml
@@ -286,7 +286,7 @@ let write_buffer ?(offset = 0) ?length message chunk =
   let length =
     match length with
     | Some length -> length
-    | None -> Lwt_bytes.length chunk - offset
+    | None -> Bigstringaf.length chunk - offset
   in
   Body.write_bigstring chunk offset length message.body
 


### PR DESCRIPTION
This is the last occurrence which brings the `unix` dependency into `dream` - I hope.