### PR TITLE
Move the TTY initializer into the main dream module

### DIFF
--- a/src/dream.ml
+++ b/src/dream.ml
@@ -22,7 +22,9 @@ include Dream__middleware.Log.Make (Ptime_clock)
 (* Initalize logs with the default reporter which uses [Ptime_clock], this
    function is a part of [Dream__middleware.Log.Make], it's why it is not
    prepended by a module name. *)
-let () = initialize ()
+let () =
+  Fmt_tty.setup_std_outputs ();
+  initialize ()
 include Dream__middleware.Echo
 
 let default_log =

--- a/src/dream.ml
+++ b/src/dream.ml
@@ -23,8 +23,7 @@ include Dream__middleware.Log.Make (Ptime_clock)
    function is a part of [Dream__middleware.Log.Make], it's why it is not
    prepended by a module name. *)
 let () =
-  Fmt_tty.setup_std_outputs ();
-  initialize ()
+  initialize ~setup_outputs:Fmt_tty.setup_std_outputs
 include Dream__middleware.Echo
 
 let default_log =

--- a/src/dune
+++ b/src/dune
@@ -9,6 +9,7 @@
   dream.middleware
   dream.pure
   dream.sql
+  fmt.tty
   graphql-lwt
   logs
   lwt

--- a/src/middleware/dune
+++ b/src/middleware/dune
@@ -6,7 +6,6 @@
   dream.cipher
   dream.pure
   fmt
-  fmt.tty
   logs
   lwt
   magic-mime

--- a/src/middleware/log.ml
+++ b/src/middleware/log.ml
@@ -352,8 +352,9 @@ struct
   let now () =
     Ptime.to_float_s (Ptime.v (Pclock.now_d_ps ()))
 
-  let initializer_ = lazy begin
+  let initializer_ ~setup_outputs = lazy begin
     if !enable then begin
+      setup_outputs () ;
       Logs.set_level ~all:true (Some !level);
       Logs.set_reporter (reporter ~now ())
     end ;
@@ -362,7 +363,7 @@ struct
 
   let set = ref false
 
-  let initialize () =
+  let initialize ~setup_outputs =
     if !set then Logs.debug (fun log -> log
       "Dream__log.initialize has already been called, ignoring this call.")
     else begin
@@ -374,7 +375,7 @@ struct
         with
           Logs_are_not_initialized -> ());
       set := true;
-      _initialized := Some initializer_
+      _initialized := Some (initializer_ ~setup_outputs)
     end
 
   (* The request logging middleware. *)

--- a/src/middleware/log.ml
+++ b/src/middleware/log.ml
@@ -354,7 +354,6 @@ struct
 
   let initializer_ = lazy begin
     if !enable then begin
-      Fmt_tty.setup_std_outputs ();
       Logs.set_level ~all:true (Some !level);
       Logs.set_reporter (reporter ~now ())
     end ;


### PR DESCRIPTION
This is the real **last** PR to be compatible with MirageOS - then, I will be able to propose something to compile a full `dream` operating system. `Fmt_tty` has some _sycalls_ and must be used into the main `dream.ml` module. This PR propose the "simpler" solution (no lazy, initialization, etc.).

According to your [comment](https://github.com/aantron/dream/pull/115#discussion_r665256282), this is probably not the right solution however. WDYT?