### PR TITLE
Fix the compilation of dream on OCaml 4.11

### DIFF
--- a/src/cipher/random.ml
+++ b/src/cipher/random.ml
@@ -8,7 +8,7 @@
 (* TODO LATER Is there something with lighter dependencies? Although perhaps
    these are not so bad... *)
 
-let _initialized = ref None
+let _initialized : unit lazy_t option ref = ref None
 
 let initialized () =
   match !_initialized with


### PR DESCRIPTION
A simple fix when OCaml 4.11 complains about weak type. Sorry for the noise.