### PR TITLE
Goodbye float, flexbox all the way

### DIFF
--- a/example/z-playground/client/client.eml.html
+++ b/example/z-playground/client/client.eml.html
@@ -43,8 +43,8 @@ let html example =
 <div id="editor">
   <header>
     <h1>Dream Playground</h1>
-    <button id="chview">Change View</button>
     <button id="run">Run</button>
+    <button id="chview">Change View</button>
     <%s! backlink %>
   </header>
   <div id="textarea"></div>

--- a/example/z-playground/client/playground.css
+++ b/example/z-playground/client/playground.css
@@ -3,8 +3,6 @@
 
   Copyright 2021 Anton Bachin */
 
-
-
 body {
   margin: 0;
   font-size: 14px;
@@ -12,33 +10,55 @@ body {
   color: #ddd;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Open Sans, Helvetica Neue, Helvetica, Arial, sans-serif;
   display: flex;
+  height: 100vh;
+  overflow-y: hidden;
 }
 
-#editor {
-  min-width: 50%;
+@supports (-webkit-touch-callout: none) {
+  body {
+    /* The hack for Safari Mobile hack */
+    height: -webkit-fill-available;
+  }
 }
 
-#client {
-  min-width: 50%;
+/* This is for when pressing Change View button */
+body.full-editor {
+  flex-direction: column;
+  overflow-y: auto;
+  height: auto;
+}
+.full-editor #editor, .full-editor #client {
+  flex: 1 1 100%;
+  width: 100%;
 }
 
-#textarea .CodeMirror {
-  height: calc(100vh - 203px);
-}
-
-#client iframe {
-  height: calc(100vh - 66px)
+#editor, #client {
+  flex: 0 0 50%;
+  width: 50%;
+  display: flex;
+  flex-direction: column;
 }
 
 @media (max-width: 1100px) {
   #editor, #client {
-    float: none;
-    width: initial;
+    width: 100%;
   }
-  body{
+  body {
     flex-direction: column;
   }
 }
+
+#textarea {
+  flex: 1 0 auto;
+}
+#textarea .CodeMirror {
+  height: 100%;
+}
+
+#client iframe {
+  flex: 1 0 auto;
+}
+
 
 
 header {
@@ -56,8 +76,8 @@ h1 {
 }
 
 #log {
-  margin: 0;
   height: 125px;
+  margin: 0;
   overflow-x: hidden;
   padding-left: 34px;
   padding-top: 14px;

--- a/example/z-playground/client/playground.js
+++ b/example/z-playground/client/playground.js
@@ -103,12 +103,8 @@ run.onclick = function () {
 };
 
 chview.onclick = function(){
-  var body = document.getElementsByTagName("body")[0];
-  if(body.style.flexDirection == "" || body.style.flexDirection == "column"){
-    body.style.flexDirection = "row"
-  }else{
-    body.style.flexDirection = "column"
-  };
+  var body = document.body;
+  body.classList.toggle("full-editor")
 }
 
 address.onkeyup = function (event) {

--- a/example/z-playground/package-lock.json
+++ b/example/z-playground/package-lock.json
@@ -1,7 +1,20 @@
 {
   "name": "dream-playground",
+  "lockfileVersion": 2,
   "requires": true,
-  "lockfileVersion": 1,
+  "packages": {
+    "": {
+      "name": "dream-playground",
+      "dependencies": {
+        "codemirror": "*"
+      }
+    },
+    "node_modules/codemirror": {
+      "version": "5.61.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.61.0.tgz",
+      "integrity": "sha512-D3wYH90tYY1BsKlUe0oNj2JAhQ9TepkD51auk3N7q+4uz7A/cgJ5JsWHreT0PqieW1QhOuqxQ2reCXV1YXzecg=="
+    }
+  },
   "dependencies": {
     "codemirror": {
       "version": "5.61.0",


### PR DESCRIPTION
As I've said in https://github.com/aantron/dream/pull/124#issuecomment-877633060

This PR removes all the fragile pixel calculations and use flexbox (shrink-grow) to control the overall layout.

I also took the opportunity to move <kbd>Change View</kbd> to the right of <kbd>Run</kbd> button because I think <kbd>Change View</kbd> is rarely used comparing to <kbd>Run</kbd>