### PR TITLE
Prevent Codemirror to grow

### DIFF
--- a/example/z-playground/client/playground.css
+++ b/example/z-playground/client/playground.css
@@ -50,9 +50,15 @@ body.full-editor {
 
 #textarea {
   flex: 1 0 auto;
+  position: relative;
 }
 #textarea .CodeMirror {
   height: 100%;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
 }
 
 #client iframe {


### PR DESCRIPTION
When there're too many lines, the editor would grow to fit the whole content.
The usual fix would be defining a maximum height on parent container of `.CodeMirror` 
and `position: relative`.

Since parent container is this case (`#textarea`) grow with its container (`#editor`), 
maximum height can't be set without resorting to manual `calc` .

This PR implement a hacks documented here: https://discuss.codemirror.net/t/size-inside-flexbox/1359/5

You can test this by making the editor has more lines than its parent container.
For example: http://dream.as/k-websocket