### PR TITLE
Playground: Refactoring CSS

### DIFF
--- a/example/z-playground/client/client.eml.html
+++ b/example/z-playground/client/client.eml.html
@@ -40,21 +40,21 @@ let html example =
 </head>
 <body>
 
-<div id="editor">
+<div id="editor" class="panel">
   <header>
     <h1>Dream Playground</h1>
     <button id="run">Run</button>
     <button id="chview">Change View</button>
     <%s! backlink %>
   </header>
-  <div id="textarea"></div>
+  <div id="textarea" class="panel-fluid"></div>
   <pre id="log"></pre>
 </div>
-<div id="client">
+<div id="client" class="panel">
   <header>
     <input id="location"></input>
   </header>
-  <iframe title="Client connecting to the playground server"></iframe>
+  <iframe title="Client connecting to the playground server" class="panel-fluid"></iframe>
 </div>
 
 <script src="/static/playground.js"></script>

--- a/example/z-playground/client/playground.css
+++ b/example/z-playground/client/playground.css
@@ -3,6 +3,74 @@
 
   Copyright 2021 Anton Bachin */
 
+/*
+
+Playground layout: 2 panels with normal element and fluid
+┌──────────────────────────────────────────────────┐
+│                                                  │
+│ body (desktop)                                   │
+│                                                  │
+│ ┌───────────────────────┐ ┌────────────────────┐ │
+│ │                       │ │                    │ │
+│ │ ┌───────────────────┐ │ │ ┌────────────────┐ │ │
+│ │ │                   │ │ │ │                │ │ │
+│ │ │ .panel-element    │ │ │ │ .panel-element │ │ │
+│ │ ├───────────────────┤ │ │ ├────────────────┤ │ │
+│ │ │                   │ │ │ │                │ │ │
+│ │ │ .panel-fluid      │ │ │ │ .panel-fluid   │ │ │
+│ │ │                   │ │ │ │                │ │ │
+│ │ │                   │ │ │ │                │ │ │
+│ │ │                   │ │ │ │                │ │ │
+│ │ │                   │ │ │ │                │ │ │
+│ │ │                   │ │ │ │                │ │ │
+│ │ │                   │ │ │ │                │ │ │
+│ │ │                   │ │ │ │                │ │ │
+│ │ │                   │ │ │ │                │ │ │
+│ │ │                   │ │ │ │                │ │ │
+│ │ │                   │ │ │ │                │ │ │
+│ │ │                   │ │ │ │                │ │ │
+│ │ │                   │ │ │ │                │ │ │
+│ │ │                   │ │ │ │                │ │ │
+│ │ └───────────────────┘ │ │ └────────────────┘ │ │
+│ │                       │ │                    │ │
+│ │                       │ │                    │ │
+│ └───────────────────────┘ └────────────────────┘ │
+│                                                  │
+└──────────────────────────────────────────────────┘
+
+This is on mobile or when pressing Change 
+┌──────────────────────────────────────────────────┐
+│                                                  │
+│ body (mobile/Change view actived)                │
+│ ┌──────────────────────────────────────────────┐ │
+│ │                                              │ │
+│ │ ┌──────────────────────────────────────────┐ │ │
+│ │ │ .panel-element                           │ │ │
+│ │ │                                          │ │ │
+│ │ ├──────────────────────────────────────────┤ │ │
+│ │ │ .panel-fluid                             │ │ │
+│ │ │                                          │ │ │
+│ │ │                                          │ │ │
+│ │ │                                          │ │ │
+│ │ │                                          │ │ │
+│ │ └──────────────────────────────────────────┘ │ │
+│ │                                              │ │
+│ ├──────────────────────────────────────────────┤ │
+│ │                                              │ │
+│ │ ┌──────────────────────────────────────────┐ │ │
+│ │ │ .panel-element                           │ │ │
+│ │ │                                          │ │ │
+│ │ ├──────────────────────────────────────────┤ │ │
+│ │ │ .panel-fluid                             │ │ │
+│ │ │                                          │ │ │
+│ │ │                                          │ │ │
+│ │ │                                          │ │ │
+│ │ └──────────────────────────────────────────┘ │ │
+│ │                                              │ │
+│ └──────────────────────────────────────────────┘ │
+│                                                  │
+└──────────────────────────────────────────────────┘
+ */
 body {
   margin: 0;
   font-size: 14px;
@@ -21,35 +89,43 @@ body {
   }
 }
 
-/* This is for when pressing Change View button */
-body.full-editor {
-  flex-direction: column;
-  overflow-y: auto;
-  height: auto;
-}
-.full-editor #editor, .full-editor #client {
-  flex: 1 1 100%;
-  width: 100%;
-}
-
-#editor, #client {
+.panel {
   flex: 0 0 50%;
   width: 50%;
   display: flex;
   flex-direction: column;
 }
+.panel-fluid {
+  flex: 1 0 auto;
+  min-height: 300px;
+}
+
+/* 
+ * Change view activation and mobile mode is the same
+ * Please ensure that they are in perfect sync
+ */
+body.full-editor {
+  flex-direction: column;
+  overflow-y: auto;
+  height: auto;
+}
+
+.full-editor .panel {
+  width: 100%;
+}
 
 @media (max-width: 1100px) {
-  #editor, #client {
-    width: 100%;
-  }
   body {
     flex-direction: column;
+    overflow-y: auto;
+    height: auto;
+  }
+  .panel {
+    width: 100%;
   }
 }
 
 #textarea {
-  flex: 1 0 auto;
   position: relative;
 }
 #textarea .CodeMirror {
@@ -60,12 +136,6 @@ body.full-editor {
   left: 0;
   right: 0;
 }
-
-#client iframe {
-  flex: 1 0 auto;
-}
-
-
 
 header {
   height: 64px;
@@ -146,8 +216,6 @@ h1 {
   background: #555;
 }
 
-
-
 /* Client */
 
 #client header {
@@ -175,7 +243,6 @@ h1 {
   width: 100%;
   background-color: white;
 }
-
 
 
 /* Syntax */


### PR DESCRIPTION
I've extracted the common layout components into classes : `.panel` and `.panel-fluid` to make CSS more maintainable. 

Details could be seen in the `playground.css` comment section. 

Please squash this PR because I've messed up with my local branches somehow