### PR TITLE
Make `Dream.redirect ?status` typesafe

### DIFF
--- a/src/dream.mli
+++ b/src/dream.mli
@@ -451,7 +451,7 @@ val json :
     {!Dream.application_json}. *)
 
 val redirect :
-  ?status:(redirection :> status) ->
+  ?status:redirection ->
   ?code:int ->
   ?headers:(string * string) list ->
     request -> string -> response promise
@@ -460,8 +460,8 @@ val redirect :
     redirection. Use [~status:`Moved_Permanently] or [~code:301] for a permanent
     redirection. The {!type-request} is used for retrieving the site prefix, if
     the string is an absolute path. Most applications don't have a site
-    prefix. 
-    
+    prefix.
+
     Warning: Browsers don't redirect if status code isn't 30x. *)
 
 val empty :

--- a/src/dream.mli
+++ b/src/dream.mli
@@ -451,7 +451,7 @@ val json :
     {!Dream.application_json}. *)
 
 val redirect :
-  ?status:status ->
+  ?status:redirection ->
   ?code:int ->
   ?headers:(string * string) list ->
     request -> string -> response promise
@@ -460,7 +460,9 @@ val redirect :
     redirection. Use [~status:`Moved_Permanently] or [~code:301] for a permanent
     redirection. The {!type-request} is used for retrieving the site prefix, if
     the string is an absolute path. Most applications don't have a site
-    prefix. *)
+    prefix. 
+    
+    Warning: Browsers don't redirect if status code isn't 30x. *)
 
 val empty :
   ?headers:(string * string) list ->

--- a/src/dream.mli
+++ b/src/dream.mli
@@ -451,7 +451,7 @@ val json :
     {!Dream.application_json}. *)
 
 val redirect :
-  ?status:redirection ->
+  ?status:(redirection :> status) ->
   ?code:int ->
   ?headers:(string * string) list ->
     request -> string -> response promise

--- a/src/pure/inmost.ml
+++ b/src/pure/inmost.ml
@@ -476,6 +476,7 @@ let redirect ?status ?code ?headers _request location =
     | None, None -> Some (`See_Other)
     | _ -> status
   in
+  let status = (status :> status option) in
   response ?status ?code ?headers location
   |> with_header "Location" location
   |> Lwt.return


### PR DESCRIPTION
This fixes #129 
As discussed on Discord, if user passes `?code` directly, Dream would respect that without any checks. 

If `code != 30x` then browsers don't redirect the new `Location` 