### PR TITLE
Tidy up flash message cookies.

### DIFF
--- a/src/middleware/flash.ml
+++ b/src/middleware/flash.ml
@@ -19,6 +19,8 @@ let storage =
 let flash_cookie =
   "dream.flash"
 
+
+
 let flash_messages inner_handler request =
   let outbox = ref [] in
   let request = Dream.with_local storage outbox request in
@@ -36,9 +38,9 @@ let flash_messages inner_handler request =
   in
   Lwt.return resp
 
+
 let (|>?) =
   Option.bind
-
 
 let flash request =
   let rec group x =

--- a/src/middleware/flash.ml
+++ b/src/middleware/flash.ml
@@ -31,10 +31,10 @@ let flash_messages inner_handler request =
   | None, [] -> response
   | Some _, [] -> Dream.set_cookie flash_cookie "" request response ~expires:0.
   | _, _ ->
-    let content =
-      List.fold_right (fun (x,y) a -> `String x :: `String y :: a) entries [] in
-    let value = `List content |> Yojson.Basic.to_string in
-    Dream.set_cookie flash_cookie value request response ~max_age:five_minutes
+  let content =
+    List.fold_right (fun (x,y) a -> `String x :: `String y :: a) entries [] in
+  let value = `List content |> Yojson.Basic.to_string in
+  Dream.set_cookie flash_cookie value request response ~max_age:five_minutes
   in
   Lwt.return resp
 

--- a/src/middleware/flash.ml
+++ b/src/middleware/flash.ml
@@ -19,23 +19,26 @@ let storage =
 let flash_cookie =
   "dream.flash"
 
-
-
 let flash_messages inner_handler request =
   let outbox = ref [] in
   let request = Dream.with_local storage outbox request in
   let%lwt response = inner_handler request in
   let entries = List.rev !outbox in
-  let content =
-    List.fold_right (fun (x,y) a -> `String x :: `String y :: a) entries [] in
-  let value = `List content |> Yojson.Basic.to_string in
-  Dream.set_cookie flash_cookie value request response ~max_age:five_minutes
-  |> Lwt.return
-
-
+  let existing = Dream.cookie flash_cookie request in
+  let resp = match existing, entries with
+  | None, [] -> response
+  | Some _, [] -> Dream.set_cookie flash_cookie "" request response ~expires:0.
+  | _, _ ->
+    let content =
+      List.fold_right (fun (x,y) a -> `String x :: `String y :: a) entries [] in
+    let value = `List content |> Yojson.Basic.to_string in
+    Dream.set_cookie flash_cookie value request response ~max_age:five_minutes
+  in
+  Lwt.return resp
 
 let (|>?) =
   Option.bind
+
 
 let flash request =
   let rec group x =


### PR DESCRIPTION
This change addresses #134. In the first flash message implementation, the middleware would create a cookie regardless of whether any messages were actually created. A better approach is to only create a cookie when there is a flash message to display on the next request and to expire an existing cookie if there are no new messages to show.