### PR TITLE
Upgrade mirage

### DIFF
--- a/dream-mirage.opam
+++ b/dream-mirage.opam
@@ -54,6 +54,7 @@ depends: [
   "bigstringaf"
   "digestif" {>= "1.0.0"}
   "lwt"
+  "tls-mirage"
   "lwt_ppx" {>= "1.2.2"}
   "letsencrypt" {>= "0.3.0"}
 ]

--- a/example/m-mirage/README.md
+++ b/example/m-mirage/README.md
@@ -36,7 +36,7 @@ address.
 
 ```sh
 $ opam install mirage
-$ mirage configure -t virtio --dhcp true --hostname <HOSTNAME>
+$ mirage configure -t virtio --dhcp true --hostname <HOSTNAME> --tls true
 $ make depends
 $ mirage build
 $ solo5-virtio-mkimage gs://dream-os
@@ -55,3 +55,20 @@ $ gcloud compute firewall-rules create http --allow tcp:443
 $ gcloud compute instances create dream-os --image dream-os --address <IP> \
   --zone europe-west1-b --machine-type f1-micro
 ```
+
+#### DreamOS locally
+
+MirageOS has several targets and so, several deployements. The most easy one is
+the `unix` target which compiles your MirageOS application into a simple
+executable:
+
+```sh
+$ mirage configure -t unix
+$ make depends
+$ mirage build
+$ ./dream --tls false --hostname localhost --port 8080
+```
+
+The TLS support is available only via a certificate given by let's encrypt. It
+requires so a domain-name and the ability to bind the server into `*:80` (and
+be able to do the let's encrypt challenge).

--- a/example/m-mirage/config.ml
+++ b/example/m-mirage/config.ml
@@ -24,6 +24,10 @@ let email =
   let doc = Key.Arg.info ~doc:"Let's encrypt E-Mail." [ "email" ] in
   Key.(create "email" Arg.(opt (some string) None doc))
 
+let tls =
+  let doc = Key.Arg.info ~doc:"HTTP server with TLS." [ "tls" ] in
+  Key.(create "tls" Arg.(opt bool false doc))
+
 let dream =
   foreign "Unikernel.Make"
     ~packages:[ package "ca-certs-nss"
@@ -35,7 +39,8 @@ let dream =
                ; abstract production
                ; abstract cert_seed
                ; abstract account_seed
-               ; abstract email ])
+               ; abstract email
+               ; abstract tls ])
     (console @-> random @-> time @-> mclock @-> pclock @-> stackv4v6 @-> job)
 
 let random = default_random

--- a/src/mirage/error_handler.ml
+++ b/src/mirage/error_handler.ml
@@ -1,5 +1,4 @@
 module Dream = Dream__pure.Inmost
-module Error = Dream__middleware.Error
 
 let log =
   Dream__middleware.Log.sub_log "dream.mirage"
@@ -10,7 +9,7 @@ let select_log = function
   | `Info -> log.info
   | `Debug -> log.debug
 
-let dump (error : Error.error) =
+let dump (error : Dream.error) =
   let buffer = Buffer.create 4096 in
   let p format = Printf.bprintf buffer format in
 
@@ -95,7 +94,7 @@ let dump (error : Error.error) =
 
   Buffer.contents buffer
 
-let customize template (error : Error.error) =
+let customize template (error : Dream.error) =
 
   (* First, log the error. *)
 
@@ -198,7 +197,7 @@ let double_faults f default =
     default ()
   end
 
-let httpaf app user's_error_handler = fun client ?request:_ error start_response ->
+let httpaf app user's_error_handler = fun client_address ?request:_ error start_response ->
   let condition, severity, caused_by = match error with
     | `Exn exn ->
       `Exn exn,
@@ -213,13 +212,13 @@ let httpaf app user's_error_handler = fun client ?request:_ error start_response
       `String "Content-Length missing or negative",
       `Error,
       `Server in
-  let error = Error.{
-    condition;
+  let error = {
+    Dream.condition;
     layer = `HTTP;
     caused_by;
     request = None;
     response = None;
-    client;
+    client= Some client_address;
     severity;
     debug = Dream.debug app;
     will_send_response = true;

--- a/src/mirage/mirage.mli
+++ b/src/mirage/mirage.mli
@@ -3,11 +3,6 @@ type response
 
 type handler = request -> response Lwt.t
 
-module Error : sig
-  type error
-  type error_handler = error -> response option Lwt.t
-end
-
 module Make
   (Pclock : Mirage_clock.PCLOCK)
   (Time : Mirage_time.S)
@@ -182,12 +177,22 @@ module Make
   val error_template :
     (string option -> response -> response Lwt.t) -> error_handler
 
-  val run :
+  val https :
        ?stop:Lwt_switch.t
     -> port:int
     -> ?prefix:string
     -> Stack.t
     -> Tls.Config.server
+    -> ?error_handler:error_handler
+    -> handler
+    -> unit Lwt.t
+
+  val http :
+       ?stop:Lwt_switch.t
+    -> port:int
+    -> ?prefix:string
+    -> ?protocol:[ `H2 | `HTTP_1_1 ]
+    -> Stack.t
     -> ?error_handler:error_handler
     -> handler
     -> unit Lwt.t


### PR DESCRIPTION
This is an upgrade of the MirageOS support which adds the HTTP (without TLS) support to easily deploy the example locally. However, it seems that `dream-mirage` was not in sync with the core of `dream`. Indeed, `dream-mirage` does not compile anymore and it's weird that the CI did not catch that.

I extended the `README.md` to explain how to deploy the example locally with the `unix` target.