### PR TITLE
Be able to launch locally a DreamOS with TLS

### DIFF
--- a/example/m-mirage/README.md
+++ b/example/m-mirage/README.md
@@ -36,7 +36,8 @@ address.
 
 ```sh
 $ opam install mirage
-$ mirage configure -t virtio --dhcp true --hostname <HOSTNAME> --tls true
+$ mirage configure -t virtio --dhcp true --hostname <HOSTNAME> --tls true \
+  --letsencrypt true --productive false
 $ make depends
 $ mirage build
 $ solo5-virtio-mkimage gs://dream-os
@@ -66,9 +67,7 @@ executable:
 $ mirage configure -t unix
 $ make depends
 $ mirage build
-$ ./dream --tls false --hostname localhost --port 8080
+$ ./dream --tls false --port 8080
+# or with you want the TLS support via a fake certificate
+$ ./dream --tls true --port 4343
 ```
-
-The TLS support is available only via a certificate given by let's encrypt. It
-requires so a domain-name and the ability to bind the server into `*:80` (and
-be able to do the let's encrypt challenge).

--- a/example/m-mirage/config.ml
+++ b/example/m-mirage/config.ml
@@ -6,7 +6,7 @@ let port =
 
 let hostname =
   let doc = Key.Arg.info ~doc:"Hostname." [ "hostname" ] in
-  Key.(create "hostname" Arg.(required string doc))
+  Key.(create "hostname" Arg.(opt string "localhost" doc))
 
 let production =
   let doc = Key.Arg.info ~doc:"Let's encrypt production environment." [ "production" ] in
@@ -28,6 +28,10 @@ let tls =
   let doc = Key.Arg.info ~doc:"HTTP server with TLS." [ "tls" ] in
   Key.(create "tls" Arg.(opt bool false doc))
 
+let letsencrypt =
+  let doc = Key.Arg.info ~doc:"Retrieve the TLS certificate from Let's encrypt." [ "letsencrypt" ] in
+  Key.(create "letsencrypt" Arg.(opt bool false doc))
+
 let dream =
   foreign "Unikernel.Make"
     ~packages:[ package "ca-certs-nss"
@@ -40,7 +44,8 @@ let dream =
                ; abstract cert_seed
                ; abstract account_seed
                ; abstract email
-               ; abstract tls ])
+               ; abstract tls
+               ; abstract letsencrypt ])
     (console @-> random @-> time @-> mclock @-> pclock @-> stackv4v6 @-> job)
 
 let random = default_random

--- a/src/mirage/mirage.ml
+++ b/src/mirage/mirage.ml
@@ -219,7 +219,16 @@ module Make (Pclock : Mirage_clock.PCLOCK) (Time : Mirage_time.S) (Stack : Mirag
       Dream__middleware.Site_prefix.chop_site_prefix;
     ]
 
-  let https ?stop ~port ?(prefix= "") stack cfg ?error_handler:(user's_error_handler= Error_handler.default) user's_dream_handler =
+  let localhost_certificate =
+    let crts = Rresult.R.failwith_error_msg
+      (X509.Certificate.decode_pem_multiple (Cstruct.of_string Dream__localhost.certificate)) in
+    let key = Rresult.R.failwith_error_msg
+      (X509.Private_key.decode_pem (Cstruct.of_string Dream__localhost.key)) in
+    `Single (crts, key)
+
+  let https ?stop ~port ?(prefix= "") stack
+    ?(cfg= Tls.Config.server ~certificates:localhost_certificate ())
+    ?error_handler:(user's_error_handler= Error_handler.default) user's_dream_handler =
     let prefix = prefix
       |> Dream__pure.Formats.from_path
       |> Dream__pure.Formats.drop_trailing_slash in

--- a/src/mirage/mirage.mli
+++ b/src/mirage/mirage.mli
@@ -182,7 +182,7 @@ module Make
     -> port:int
     -> ?prefix:string
     -> Stack.t
-    -> Tls.Config.server
+    -> ?cfg:Tls.Config.server
     -> ?error_handler:error_handler
     -> handler
     -> unit Lwt.t


### PR DESCRIPTION
A final fix for #145 with the support of TLS for a local usage. Note that we depends on `tls.0.14.0` now and it seems fine according to my context.