### PR TITLE
Windows: Addresses missing SIGPIPE for Windows

### DIFF
--- a/src/http/http.ml
+++ b/src/http/http.ml
@@ -813,7 +813,9 @@ let run
     ?(adjust_terminal = true)
     user's_dream_handler =
 
-  Sys.(set_signal sigpipe Signal_ignore);
+  let () = if Sys.unix then
+    Sys.(set_signal sigpipe Signal_ignore)
+  in
 
   let adjust_terminal =
     adjust_terminal && Sys.os_type <> "Win32" && Unix.(isatty stderr) in


### PR DESCRIPTION
Since SIGPIPE is not found on Windows, this PR adds alternate code path for Windows.