### PR TITLE
Allow log levels to be configured per-source.

### DIFF
--- a/dream.opam
+++ b/dream.opam
@@ -55,7 +55,7 @@ depends: [
   "conf-libev" {os != "win32"}
   "cstruct" {>= "6.0.0"}
   "dune" {>= "2.7.0"}  # --instrument-with.
-  "fmt" {>= "0.8.7"}  # `Italic.
+  "fmt" {>= "0.8.7" & <= "0.8.9" }  # `Italic.
   "graphql_parser"
   "graphql-lwt"
   "hmap"
@@ -92,6 +92,7 @@ depends: [
   "faraday-lwt-unix"
   "psq"  # h2.
   "result"  # http/af, websocket/af.
+  "letsencrypt" {= "0.3.0"}
 
   # Testing, development.
   "alcotest" {with-test}

--- a/example/w-flash/flash.eml.ml
+++ b/example/w-flash/flash.eml.ml
@@ -18,6 +18,10 @@ let result request =
   </html>
 
 let () =
+  Dream.initialize_log ~level:`Warning ();
+  Dream.set_log_level "jst_log" `Info;
+  Dream.set_log_level "dream.flash" `Info;
+  let sublog = Dream.sub_log "jst_log" in
   Dream.run
   @@ Dream.logger
   @@ Dream.memory_sessions
@@ -31,8 +35,11 @@ let () =
     Dream.post "/"
       (fun request ->
         match%lwt Dream.form request with
-        | `Ok ["text", text] ->
+          | `Ok ["text", text] ->
           let () = Dream.put_flash "Info" text request in
+          sublog.info (fun log -> log ~request "%s" "Test log message.");
+          Dream.set_log_level "jst_log" `Error;
+          sublog.info (fun log -> log ~request "%s" "Shouldn't see this.");
           Dream.redirect request "/result"
         | _ ->
           Dream.redirect request "/");

--- a/src/dream.mli
+++ b/src/dream.mli
@@ -1710,6 +1710,7 @@ val initialize_log :
   ?backtraces:bool ->
   ?async_exception_hook:bool ->
   ?level:[< log_level ] ->
+  ?custom_levels: (string * [< log_level ]) list ->
   ?enable:bool ->
     unit -> unit
 (** Initializes Dream's log with the given settings.

--- a/src/dream.mli
+++ b/src/dream.mli
@@ -1688,7 +1688,8 @@ type sub_log = {
 }
 (** Sub-logs. See {!Dream.val-sub_log} right below. *)
 
-val sub_log : string -> sub_log
+
+val sub_log : ?level:[< log_level] -> string -> sub_log
 (** Creates a new sub-log with the given name. For example,
 
     {[
@@ -1702,6 +1703,10 @@ val sub_log : string -> sub_log
       log.error (fun log -> log ~request "Validation failed")
     ]}
 
+    - [?level] sets the log level threshold for this sub-log only.
+      If not provided, falls back to the last value configured by `set_log_level`
+      for the logger name, or to the global log level if that is undefined.
+
     See [README] of example
     {{:https://github.com/aantron/dream/tree/master/example/a-log#files}
     [a-log]}. *)
@@ -1710,7 +1715,6 @@ val initialize_log :
   ?backtraces:bool ->
   ?async_exception_hook:bool ->
   ?level:[< log_level ] ->
-  ?custom_levels: (string * [< log_level ]) list ->
   ?enable:bool ->
     unit -> unit
 (** Initializes Dream's log with the given settings.
@@ -1731,12 +1735,15 @@ val initialize_log :
       [Lwt.async_exception_hook]} so as to forward all asynchronous exceptions
       to the logger, and not terminate the process.
 
-    - [~level] sets the log level threshould for the entire binary. The default
+    - [~level] sets the log level threshold for the entire binary. The default
       is [`Info].
 
     - [~enable:false] disables Dream logging completely. This can help sanitize
       output during testing. *)
 
+
+val set_log_level : string -> [< log_level ] -> unit
+(** Configure the sub-log with the input name to use a specific log threshold. *)
 
 
 (** {1 Errors}

--- a/src/vendor/dune
+++ b/src/vendor/dune
@@ -5,21 +5,21 @@
   (name paf)
   (public_name dream-mirage.paf)
   (modules paf)
-  (libraries faraday bigstringaf ke mimic)))
+  (libraries faraday bigstringaf ke mimic astring)))
 
 (subdir paf/lib
  (library
   (name alpn)
   (public_name dream-mirage.paf.alpn)
   (modules alpn)
-  (libraries dream-mirage.paf dream.httpaf dream.h2)))
+  (libraries dream-mirage.paf dream.httpaf dream.h2 astring)))
 
 (subdir paf/lib
  (library
   (name paf_mirage)
   (public_name dream-mirage.paf.mirage)
   (modules paf_mirage)
-  (libraries dream-mirage.paf tls-mirage mirage-time mirage-stack dream-mirage.paf.alpn)))
+  (libraries dream-mirage.paf tls-mirage mirage-time mirage-stack dream-mirage.paf.alpn astring)))
 
 (subdir paf/lib
  (library
@@ -28,7 +28,7 @@
   (public_name dream-mirage.paf.le)
   (modules lE)
   (libraries dream.httpaf dream-mirage.paf mirage-time mirage-stack duration tls-mirage emile
-    letsencrypt)))
+    letsencrypt astring)))
 
 (subdir gluten/lib
  (library


### PR DESCRIPTION
This change proposes an update to `Dream.initialize_log` that allows log levels to be specified for individual log sources.

This is motivated by comments in #90. There, @aantron mentioned the need for a way to configure log level per source, which would be useful for working with logs related to flash messages.

**Example Usage**
```ocaml
let () =
  Dream.initialize_log
    ~level:`Warning
    ~custom_levels:[("dream.flash", `Info)]   (* NEW *)
    ();
  Dream.run
  ...
``` 

The change introduces an optional argument called `custom_levels` that accepts an association list. Sources not named in `~custom_levels` are set to `~level`, so `Dream.initialize_log` retains its original behavior when `~custom_levels` is not used.