### PR TITLE
set the resolutions for Apple M1 build, remove ocamlfind-secondary for esy build in 2-middleware example

### DIFF
--- a/example/2-middleware/esy.json
+++ b/example/2-middleware/esy.json
@@ -5,11 +5,11 @@
     "ocaml": "4.12.x"
   },
   "devDependencies": {
-    "@opam/ocaml-lsp-server": "*",
-    "@opam/ocamlfind-secondary": "*"
+    "@opam/ocaml-lsp-server": "*"
   },
   "resolutions": {
-    "@opam/conf-libev": "esy-packages/libev:package.json#0b5eb6685b688649045aceac55dc559f6f21b829"
+    "@opam/conf-libev": "esy-packages/libev:package.json#0b5eb6685b688649045aceac55dc559f6f21b829",
+    "esy-openssl": "esy-packages/esy-openssl#619ae2d46ca981ec26ab3287487ad98b157a01d1"
   },
   "scripts": {
     "start": "dune exec --root . ./middleware.exe"


### PR DESCRIPTION
# Changes

Only for the 2-middleware example:

- [x] Removed `ocamlfind-secondary`. Based on conversations in https://github.com/aantron/dream/issues/160 it is not necessary
- [x] Added appropriate esy-openssl resolution in `esy.json` to enable build on arm64

# Testing

- [x] Tested build and run on x86-64 osx machine
- [x] Tested build and run on arm64 osx machine
