### PR TITLE
Address ECONNRESET in issue #118 

### DIFF
--- a/dream.opam
+++ b/dream.opam
@@ -55,6 +55,7 @@ depends: [
   "conf-libev" {os != "win32"}
   "cstruct" {>= "6.0.0"}
   "dune" {>= "2.7.0"}  # --instrument-with.
+  "emile"
   "fmt" {>= "0.8.7"}  # `Italic.
   "graphql_parser"
   "graphql-lwt"
@@ -64,9 +65,12 @@ depends: [
   "lwt_ssl"
   "logs" {>= "0.5.0"}
   "magic-mime"
+  "mimic"
   "mirage-clock"
   "mirage-crypto" {>= "0.8.1"}  # AES-256-GCM.
   "mirage-crypto-rng" {>= "0.8.0"}  # Signature of initialize.
+  "mirage-time"
+  "mirage-stack"
   "multipart_form" {>= "0.3.0"}
   "ocaml" {>= "4.08.0"}
   "ssl" {>= "0.5.8"}  # Ssl.get_negotiated_alpn_protocol.

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,2 @@
 (lang dune 2.7)
+(cram enable)

--- a/src/http/error_handler.ml
+++ b/src/http/error_handler.ml
@@ -117,40 +117,46 @@ let customize template (error : Dream.error) =
 
   (* First, log the error. *)
 
+  let log_handler condition (error : Dream.error)  =
+     let client =
+       match error.client with
+       | None -> ""
+       | Some client ->  " (" ^ client ^ ")"
+     in
+
+     let layer =
+       match error.layer with
+       | `TLS -> ["TLS" ^ client]
+       | `HTTP -> ["HTTP" ^ client]
+       | `HTTP2 -> ["HTTP/2" ^ client]
+       | `WebSocket -> ["WebSocket" ^ client]
+       | `App -> []
+     in
+
+     let description, backtrace =
+       match condition with
+       | `String string -> string, ""
+       | `Exn exn ->
+         let backtrace = Printexc.get_backtrace () in
+         Printexc.to_string exn, backtrace
+     in
+
+     let message = String.concat ": " (layer @ [description]) in
+
+     select_log error.severity (fun log ->
+       log ?request:error.request "%s" message);
+     backtrace |> Dream__middleware.Log.iter_backtrace (fun line ->
+       select_log error.severity (fun log ->
+         log ?request:error.request "%s" line))
+  in
   begin match error.condition with
   | `Response _ -> ()
-  | `String _ | `Exn _ as condition ->
-
-    let client =
-      match error.client with
-      | None -> ""
-      | Some client ->  " (" ^ client ^ ")"
-    in
-
-    let layer =
-      match error.layer with
-      | `TLS -> ["TLS" ^ client]
-      | `HTTP -> ["HTTP" ^ client]
-      | `HTTP2 -> ["HTTP/2" ^ client]
-      | `WebSocket -> ["WebSocket" ^ client]
-      | `App -> []
-    in
-
-    let description, backtrace =
-      match condition with
-      | `String string -> string, ""
-      | `Exn exn ->
-        let backtrace = Printexc.get_backtrace () in
-        Printexc.to_string exn, backtrace
-    in
-
-    let message = String.concat ": " (layer @ [description]) in
-
-    select_log error.severity (fun log ->
-      log ?request:error.request "%s" message);
-    backtrace |> Dream__middleware.Log.iter_backtrace (fun line ->
-      select_log error.severity (fun log ->
-        log ?request:error.request "%s" line))
+  (* TODO is this the right place to handle lower level connection resets? *)
+  | `Exn (Unix.Unix_error (Unix.ECONNRESET, _, _)) ->
+     let condition = `String "Connection Reset at Client" in
+     let severity = `Info in
+     log_handler condition {error with condition; severity}
+  | `String _ | `Exn _ as condition -> log_handler condition error
   end;
 
   (* If Dream will not send a response for this error, we are done after

--- a/test/cram/dune
+++ b/test/cram/dune
@@ -1,0 +1,2 @@
+(cram
+ (applies_to :whole_subtree))

--- a/test/cram/http/dune
+++ b/test/cram/http/dune
@@ -1,0 +1,6 @@
+(executable
+  (name econnreset)
+  (libraries dream))
+
+(cram
+  (deps %{exe:econnreset.exe}))

--- a/test/cram/http/econnreset.ml
+++ b/test/cram/http/econnreset.ml
@@ -1,0 +1,34 @@
+(* This file is part of Dream, released under the MIT license. See LICENSE.md
+   for details, or visit https://github.com/aantron/dream.
+
+   Copyright 2021 Anton Bachin *)
+
+let serve port =
+  print_endline "server mode";
+  Dream.run ~greeting:false ~port (fun _ -> Unix.sleepf 10.0; Dream.html "Hello")
+
+let client port =
+  print_endline "client mode";
+  let open Unix in
+  let fd = socket PF_INET6 SOCK_STREAM 0 in
+  (* force the client to send a TCP RST packet if it fails during connection *)
+  setsockopt_optint fd SO_LINGER (Some 0);
+  let _ = connect fd (ADDR_INET (inet6_addr_loopback ,port)) in
+  ignore @@ failwith "sending RST";
+  shutdown fd SHUTDOWN_ALL
+
+let () =
+  let server = ref(false) in
+  let port = ref(-1) in
+  let usage = "Test for ECONNRESET errors being reported" in
+  Arg.parse [
+    "-p", Set_int port, "sets the port (required)";
+    "-s", Set server, "enables the server on port [port], if not set sends a TCP RST on [port]"
+  ] (fun _ -> ()) usage;
+
+  let port = !port in
+  if port > 65535 || port < 1025 then failwith "Port argument (-p) must set and be between 1025-65535";
+
+  if !server then serve port
+  else client port
+

--- a/test/cram/http/econnreset.ml
+++ b/test/cram/http/econnreset.ml
@@ -13,21 +13,36 @@ let client port =
   let fd = socket PF_INET6 SOCK_STREAM 0 in
   (* force the client to send a TCP RST packet if it fails during connection *)
   setsockopt_optint fd SO_LINGER (Some 0);
-  let _ = connect fd (ADDR_INET (inet6_addr_loopback ,port)) in
-  ignore @@ failwith "sending RST";
-  shutdown fd SHUTDOWN_ALL
+  let _ = connect fd (ADDR_INET (inet6_addr_loopback, port)) in
+  ignore @@ failwith "sending RST"
+
+let print_open_port () =
+  let open Unix in
+  let fd = socket PF_INET6 SOCK_STREAM 0 in
+  bind fd (ADDR_INET (inet6_addr_loopback, 0));
+
+  begin match getsockname fd with
+  | ADDR_INET (_, port) -> Printf.printf "%d\n" port
+  | _ -> failwith "Invalid Socket response"
+  end;
+
+  exit 0
 
 let () =
   let server = ref(false) in
   let port = ref(-1) in
   let usage = "Test for ECONNRESET errors being reported" in
   Arg.parse [
-    "-p", Set_int port, "sets the port (required)";
+    "-p", Set_int port, "sets the port to listen on or connect to, if not specified, prints an available TCP port and exits";
     "-s", Set server, "enables the server on port [port], if not set sends a TCP RST on [port]"
   ] (fun _ -> ()) usage;
 
   let port = !port in
-  if port > 65535 || port < 1025 then failwith "Port argument (-p) must set and be between 1025-65535";
+
+  (* see if we need to print an open port or validate the port *)
+  if port = -1 then print_open_port ()
+  else if port > 65535 || port < 1025
+  then failwith "Port argument (-p) must set and be between 1025-65535";
 
   if !server then serve port
   else client port

--- a/test/cram/http/issue_118_econnreset.t
+++ b/test/cram/http/issue_118_econnreset.t
@@ -1,12 +1,13 @@
 Start a Dream server
 
-  $ ./econnreset.exe -s -p 9191 &> test.log &
+  $ export PORT=$(./econnreset.exe)
+  $ ./econnreset.exe -s -p "${PORT}" &> test.log &
   $ export PID=$!
   $ sleep 1
 
 Force a connection reset - will log a few errors
 
-  $ ./econnreset.exe -p 9191
+  $ ./econnreset.exe -p "${PORT}"
 
 Does the log contain an error line for the ECONNRESET? An error code of [1] is "good", meaning no line was found.
 

--- a/test/cram/http/issue_118_econnreset.t
+++ b/test/cram/http/issue_118_econnreset.t
@@ -1,0 +1,18 @@
+Start a Dream server
+
+  $ ./econnreset.exe -s -p 9191 &> test.log &
+  $ export PID=$!
+  $ sleep 1
+
+Force a connection reset - will log a few errors
+
+  $ ./econnreset.exe -p 9191
+
+Does the log contain an error line for the ECONNRESET? An error code of [1] is "good", meaning no line was found.
+
+  $ kill "${PID}"
+  $ cat test.log | grep 'ERROR' | grep 'ECONNRESET'
+
+Does the log contain an info line with custom string for the ECONNRESET?
+
+  $ cat test.log | grep 'INFO' | grep 'Connection Reset at Client' | wc -l


### PR DESCRIPTION
# Summary

I took a few liberties here, so please feel free to recommend alternate strategies for any of the following:

1. I enabled Cram tests in the `dune-project`. I felt that cram tests would be the best way to make the TCP RST packet issue pop up. I generally like how this turned out, however I don't really like how it does open TCP port selection.
2. I added a few dependencies in the `dream.opam` file, such as `emile` and `mimic`. I personally run Dream's build in an esy "harness" of sorts, and it was not happy about those undeclared dependencies. Not a major issue to remove if this adds too much clutter or is undesired.
3. The place where I added the fix seems like it is awfully naive to the structure of Dream's error handling. The Cram test itself validates the fix, (although I do need to test a bit more broadly, only osx/x64 so far, and I haven't tested ipv4 yet) so I'm happy with it as a one-off but I think there likely should be some sort of designated "error mangler" function for these types of things.

# What has been done?

- [x] Write a test that demonstrates the behavior in ipv6
- [ ] Write a test that demonstrates the behavior in ipv4
- [x] Update the error logging "middleware" to identify ECONNRESETs and downgrade to <code>`Info</code>
- [x] Test OSX
- [ ] Test Linux
- [ ] Test Windows if I can