### PR TITLE
Allow log levels to be configured per-source.

### DIFF
--- a/src/dream.mli
+++ b/src/dream.mli
@@ -1688,7 +1688,8 @@ type sub_log = {
 }
 (** Sub-logs. See {!Dream.val-sub_log} right below. *)
 
-val sub_log : string -> sub_log
+
+val sub_log : ?level:[< log_level] -> string -> sub_log
 (** Creates a new sub-log with the given name. For example,
 
     {[
@@ -1701,6 +1702,10 @@ val sub_log : string -> sub_log
     {[
       log.error (fun log -> log ~request "Validation failed")
     ]}
+
+    - [?level] sets the log level threshold for this sub-log only.
+      If not provided, falls back to the last value configured by `set_log_level`
+      for the logger name, or to the global log level if that is undefined.
 
     See [README] of example
     {{:https://github.com/aantron/dream/tree/master/example/a-log#files}
@@ -1730,12 +1735,15 @@ val initialize_log :
       [Lwt.async_exception_hook]} so as to forward all asynchronous exceptions
       to the logger, and not terminate the process.
 
-    - [~level] sets the log level threshould for the entire binary. The default
+    - [~level] sets the log level threshold for the entire binary. The default
       is [`Info].
 
     - [~enable:false] disables Dream logging completely. This can help sanitize
       output during testing. *)
 
+
+val set_log_level : string -> [< log_level ] -> unit
+(** Configure the sub-log with the input name to use a specific log threshold. *)
 
 
 (** {1 Errors}

--- a/src/dream.mli
+++ b/src/dream.mli
@@ -1688,7 +1688,6 @@ type sub_log = {
 }
 (** Sub-logs. See {!Dream.val-sub_log} right below. *)
 
-
 val sub_log : ?level:[< log_level] -> string -> sub_log
 (** Creates a new sub-log with the given name. For example,
 
@@ -1703,9 +1702,9 @@ val sub_log : ?level:[< log_level] -> string -> sub_log
       log.error (fun log -> log ~request "Validation failed")
     ]}
 
-    - [?level] sets the log level threshold for this sub-log only.
-      If not provided, falls back to the last value configured by `set_log_level`
-      for the logger name, or to the global log level if that is undefined.
+    [?level] sets the log level threshold for this sub-log only. If not
+    provided, falls back to the global log level set by {!Dream.initialize_log},
+    unless {!Dream.set_log_level} is used.
 
     See [README] of example
     {{:https://github.com/aantron/dream/tree/master/example/a-log#files}
@@ -1741,9 +1740,9 @@ val initialize_log :
     - [~enable:false] disables Dream logging completely. This can help sanitize
       output during testing. *)
 
-
 val set_log_level : string -> [< log_level ] -> unit
-(** Configure the sub-log with the input name to use a specific log threshold. *)
+(** Set the log level threshold of the given sub-log. *)
+
 
 
 (** {1 Errors}

--- a/src/middleware/log.ml
+++ b/src/middleware/log.ml
@@ -225,7 +225,6 @@ let to_logs_level l =
   | `Info -> Logs.Info
   | `Debug -> Logs.Debug
 
-
 exception Logs_are_not_initialized
 
 let setup_logs =
@@ -265,7 +264,6 @@ let sub_log ?level:level_ name =
      ?tags argument. It has a ?request argument instead. If ~request is given,
      m' immediately tries to retrieve the request id, put it into a Logs tag,
      and call Logs' m with the user's formatting arguments and the tag. *)
-
   let forward ~(destination_log : _ Logs.log) user's_k =
     let `Initialized = initialized () in
 
@@ -283,7 +281,8 @@ let sub_log ?level:level_ name =
         log ~tags format_and_arguments))
   in
 
-  let level = List.find Option.is_some [
+  let level =
+    List.find Option.is_some [
       Option.map to_logs_level level_;
       List.assoc_opt name !custom_log_levels;
       Some !level
@@ -294,8 +293,10 @@ let sub_log ?level:level_ name =
   let src = Logs.Src.create name in
   let (module Log) = Logs.src_log src in
   Logs.Src.set_level src level;
-  custom_log_levels := (name, Option.get level) :: List.remove_assoc name !custom_log_levels;
+  custom_log_levels :=
+    (name, Option.get level)::(List.remove_assoc name !custom_log_levels);
   sources := (name, src) :: (List.remove_assoc name !sources);
+
   {
     error =   (fun k -> forward ~destination_log:Log.err   k);
     warning = (fun k -> forward ~destination_log:Log.warn  k);
@@ -343,7 +344,6 @@ let set_up_exception_hook () =
       |> iter_backtrace (fun line -> log.error (fun log -> log "%s" line))
   end
 
-
 let initialize_log
     ?(backtraces = true)
     ?(async_exception_hook = true)
@@ -370,10 +370,10 @@ let initialize_log
 
 let set_log_level name level =
   let level = to_logs_level level in
-  custom_log_levels := (name, level) :: (List.remove_assoc name !custom_log_levels);
+  custom_log_levels :=
+    (name, level)::(List.remove_assoc name !custom_log_levels);
   let src = List.assoc_opt name !sources in
   Option.iter (fun s -> Logs.Src.set_level s (Some level)) src
-
 
 module Make (Pclock : Mirage_clock.PCLOCK) =
 struct


### PR DESCRIPTION
This change updates the logging API to allow log levels for sub-logs to be customized. This is a revision of #159, rebased on the latest in master for easier review. The change is motivated by issue #90; configurable log levels would assist with debug and warning logs for flash messages.

The change adds an optional argument to set the level of a `sub-log` at creation:
```ocaml
Dream.sub_log : ?level:[< log_level ] -> string -> sub_log
```
as well as a new function to set the log level afterward:
```ocaml
Dream.set_log_level : string -> [< log_level ] -> unit
```

**Example Usage**
```ocaml
let () =
  Dream.initialize_log ~level:`Warning ();
  Dream.set_log_level "dream.flash" `Info;
  let app_log = Dream.sub_log ~level:`Info "my_app" in 
  Dream.run
  ...
  (* Now log messages on my_app and dream.flash will show if they are of info-level or higher.
     Other messages must be warning-level or higher to be displayed.*)
```