### PR TITLE
Issue 90: Add additional instrumentation for flash messages.

### DIFF
--- a/example/w-flash/README.md
+++ b/example/w-flash/README.md
@@ -48,6 +48,8 @@ into cookies and reads them back out:
 
 ```ocaml
 let () =
+  Dream.initialize_log ~level:`Info ();
+  Dream.set_log_level "dream.flash" `Debug;
   Dream.run
   @@ Dream.logger
   @@ Dream.memory_sessions
@@ -73,6 +75,16 @@ let () =
 
   ]
   @@ Dream.not_found
+```
+
+The example configures a custom log level for flash messages using
+`Dream.set_log_level`. Setting this to "debug" means the server logs
+will display a log point summarizing the flash messages on every
+request, like this:
+
+```
+10.11.21 01:48:21.629       dream.log  INFO REQ 3 GET /result ::1:39808 Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0
+10.11.21 01:48:21.629     dream.flash DEBUG REQ 3 Flash messages: Info: Some Message
 ```
 
 <pre><code><b>$ cd example/w-flash</b>

--- a/example/w-flash/README.md
+++ b/example/w-flash/README.md
@@ -48,7 +48,6 @@ into cookies and reads them back out:
 
 ```ocaml
 let () =
-  Dream.initialize_log ~level:`Info ();
   Dream.set_log_level "dream.flash" `Debug;
   Dream.run
   @@ Dream.logger

--- a/example/w-flash/flash.eml.ml
+++ b/example/w-flash/flash.eml.ml
@@ -33,8 +33,8 @@ let () =
     Dream.post "/"
       (fun request ->
         match%lwt Dream.form request with
-          | `Ok ["text", text] ->
-            let () = Dream.put_flash "Info" text request in
+        | `Ok ["text", text] ->
+          let () = Dream.put_flash "Info" text request in
           Dream.redirect request "/result"
         | _ ->
           Dream.redirect request "/");

--- a/example/w-flash/flash.eml.ml
+++ b/example/w-flash/flash.eml.ml
@@ -18,6 +18,8 @@ let result request =
   </html>
 
 let () =
+  Dream.initialize_log ~level:`Info ();
+  Dream.set_log_level "dream.flash" `Debug;
   Dream.run
   @@ Dream.logger
   @@ Dream.memory_sessions
@@ -31,8 +33,8 @@ let () =
     Dream.post "/"
       (fun request ->
         match%lwt Dream.form request with
-        | `Ok ["text", text] ->
-          let () = Dream.put_flash "Info" text request in
+          | `Ok ["text", text] ->
+            let () = Dream.put_flash "Info" text request in
           Dream.redirect request "/result"
         | _ ->
           Dream.redirect request "/");

--- a/example/w-flash/flash.eml.ml
+++ b/example/w-flash/flash.eml.ml
@@ -18,7 +18,6 @@ let result request =
   </html>
 
 let () =
-  Dream.initialize_log ~level:`Info ();
   Dream.set_log_level "dream.flash" `Debug;
   Dream.run
   @@ Dream.logger

--- a/src/middleware/flash.ml
+++ b/src/middleware/flash.ml
@@ -21,10 +21,13 @@ let flash_cookie =
 
 (* This is a soft limit. Encryption and base64 encoding increase the
    original size of the cookie text by ~4/3.*)
-let content_byte_size_limit = 3072
+let content_byte_size_limit =
+  3072
 
 let (|>?) =
   Option.bind
+
+
 
 let flash request =
   let rec group x =
@@ -57,20 +60,21 @@ let put_flash category message request =
   in
   outbox := (category, message)::!outbox
 
+
+
 let flash_messages inner_handler request =
+  log.debug (fun log ->
+    let current =
+      flash request
+      |> List.map (fun (p,q) -> p ^ ": " ^ q)
+      |> String.concat ", " in
+    if String.length current > 0 then
+      log ~request "Flash messages: %s" current
+    else
+      log ~request "%s" "No flash messages.");
   let outbox = ref [] in
   let request = Dream.with_local storage outbox request in
   let existing = Dream.cookie flash_cookie request in
-  log.debug (fun log ->
-      let current =
-        flash request
-        |> List.map (fun (p,q) -> p ^ ": " ^ q)
-        |> String.concat ", " in
-      if String.length current > 0 then
-        log ~request "Flash messages: %s" current
-      else
-        log ~request "%s" "No flash messages."
-    );
   let%lwt response = inner_handler request in
   let entries = List.rev !outbox in
   let response =
@@ -83,13 +87,15 @@ let flash_messages inner_handler request =
         List.fold_right (fun (x,y) a -> `String x :: `String y :: a) entries []
       in
       let value = `List content |> Yojson.Basic.to_string in
-      let () = if String.length value >= content_byte_size_limit
-        then
+      let () =
+        if String.length value >= content_byte_size_limit then
           log.warning (fun log ->
-              log ~request
-                "Flash messages exceed soft size limit (%d bytes)"
-                content_byte_size_limit)
-          else () in
+            log ~request
+              "Flash messages exceed soft size limit (%d bytes)"
+              content_byte_size_limit)
+        else
+          ()
+      in
       Dream.set_cookie flash_cookie value request response ~max_age:five_minutes
   in
   Lwt.return response

--- a/src/middleware/flash.ml
+++ b/src/middleware/flash.ml
@@ -46,7 +46,6 @@ let flash request =
   in
   Option.value x ~default:[]
 
-
 let put_flash category message request =
   let outbox =
     match Dream.local storage request with
@@ -57,7 +56,6 @@ let put_flash category message request =
       failwith message
   in
   outbox := (category, message)::!outbox
-
 
 let flash_messages inner_handler request =
   let outbox = ref [] in

--- a/src/middleware/flash.ml
+++ b/src/middleware/flash.ml
@@ -68,7 +68,6 @@ let flash_messages inner_handler request =
         flash request
         |> List.map (fun (p,q) -> p ^ ": " ^ q)
         |> String.concat ", " in
-
       if String.length current > 0 then
         log ~request "Flash messages: %s" current
       else

--- a/src/middleware/flash.ml
+++ b/src/middleware/flash.ml
@@ -60,8 +60,6 @@ let put_flash category message request =
 let flash_messages inner_handler request =
   let outbox = ref [] in
   let request = Dream.with_local storage outbox request in
-  let%lwt response = inner_handler request in
-  let entries = List.rev !outbox in
   let existing = Dream.cookie flash_cookie request in
   log.debug (fun log ->
       let current =
@@ -73,6 +71,8 @@ let flash_messages inner_handler request =
       else
         log ~request "%s" "No flash messages."
     );
+  let%lwt response = inner_handler request in
+  let entries = List.rev !outbox in
   let response =
     match existing, entries with
     | None, [] -> response

--- a/src/middleware/flash.ml
+++ b/src/middleware/flash.ml
@@ -19,29 +19,9 @@ let storage =
 let flash_cookie =
   "dream.flash"
 
-
-
-let flash_messages inner_handler request =
-  let outbox = ref [] in
-  let request = Dream.with_local storage outbox request in
-  let%lwt response = inner_handler request in
-  let entries = List.rev !outbox in
-  let existing = Dream.cookie flash_cookie request in
-  let response =
-    match existing, entries with
-    | None, [] -> response
-    | Some _, [] ->
-      Dream.set_cookie flash_cookie "" request response ~expires:0.
-    | _, _ ->
-      let content =
-        List.fold_right (fun (x,y) a -> `String x :: `String y :: a) entries []
-      in
-      let value = `List content |> Yojson.Basic.to_string in
-      Dream.set_cookie flash_cookie value request response ~max_age:five_minutes
-  in
-  Lwt.return response
-
-
+(* This is a soft limit. Encryption and base64 encoding increase the
+   original size of the cookie text by ~4/3.*)
+let content_byte_size_limit = 3072
 
 let (|>?) =
   Option.bind
@@ -66,6 +46,7 @@ let flash request =
   in
   Option.value x ~default:[]
 
+
 let put_flash category message request =
   let outbox =
     match Dream.local storage request with
@@ -76,3 +57,42 @@ let put_flash category message request =
       failwith message
   in
   outbox := (category, message)::!outbox
+
+
+let flash_messages inner_handler request =
+  let outbox = ref [] in
+  let request = Dream.with_local storage outbox request in
+  let%lwt response = inner_handler request in
+  let entries = List.rev !outbox in
+  let existing = Dream.cookie flash_cookie request in
+  log.debug (fun log ->
+      let current =
+        flash request
+        |> List.map (fun (p,q) -> p ^ ": " ^ q)
+        |> String.concat ", " in
+
+      if String.length current > 0 then
+        log ~request "Flash messages: %s" current
+      else
+        log ~request "%s" "No flash messages."
+    );
+  let response =
+    match existing, entries with
+    | None, [] -> response
+    | Some _, [] ->
+      Dream.set_cookie flash_cookie "" request response ~expires:0.
+    | _, _ ->
+      let content =
+        List.fold_right (fun (x,y) a -> `String x :: `String y :: a) entries []
+      in
+      let value = `List content |> Yojson.Basic.to_string in
+      let () = if String.length value >= content_byte_size_limit
+        then
+          log.warning (fun log ->
+              log ~request
+                "Flash messages exceed soft size limit (%d bytes)"
+                content_byte_size_limit)
+          else () in
+      Dream.set_cookie flash_cookie value request response ~max_age:five_minutes
+  in
+  Lwt.return response

--- a/src/middleware/log.ml
+++ b/src/middleware/log.ml
@@ -369,6 +369,9 @@ let initialize_log
   ()
 
 let set_log_level name level =
+  (* If logging hasn't been initialized, trigger this so that
+     configuration of log levels can proceed. *)
+  let `Initialized = initialized () in
   let level = to_logs_level level in
   custom_log_levels :=
     (name, level)::(List.remove_assoc name !custom_log_levels);


### PR DESCRIPTION
This change addresses #90. It introduces a new debug log point that records the current state of the flash message cookie on every request. Using the custom log levels introduced in #171, developers can easily set the `dream.flash` log source to debug level to trace their flash messages. The flash message example (`w-flash`) has been updated to illustrate how to do this.

On some browsers (for example, Firefox) cookies are limited to a maximum of 4096 bytes; above this limit, a browser may drop the cookie. Since this can prevent flash messages from appearing, I've also included a warning log point to alert developers when their message content is too big.