### PR TITLE
Fix `make depends` command on DreamOS

### DIFF
--- a/example/m-mirage/config.ml
+++ b/example/m-mirage/config.ml
@@ -35,8 +35,8 @@ let letsencrypt =
 let dream =
   foreign "Unikernel.Make"
     ~packages:[ package "ca-certs-nss"
-              ; package "dns-client.mirage"
-              ; package "dream-mirage.paf.le"
+              ; package "dns-client" ~sublibs:[ "mirage" ]
+              ; package "dream-mirage" ~sublibs:[ "paf.le" ]
               ; package "dream-mirage" ]
     ~keys:Key.([ abstract port
                ; abstract hostname


### PR DESCRIPTION
I wrote the `config.ml` too fast. We must use `sublibs` for sub-libraries to be able to generate a well-formed `opam` file.