### PR TITLE
Implement WebSockets on top of the new streams

### DIFF
--- a/src/dream.mli
+++ b/src/dream.mli
@@ -732,9 +732,11 @@ val body_stream : 'a message -> stream
 (* TODO Argument order? *)
 val next :
   stream ->
-  data:(buffer -> int -> int -> unit) ->
+  data:(buffer -> int -> int -> bool -> unit) ->
   close:(unit -> unit) ->
   flush:(unit -> unit) ->
+  ping:(unit -> unit) ->
+  pong:(unit -> unit) ->
     unit
 (** Waits for the next stream event, and calls:
 

--- a/src/dream.mli
+++ b/src/dream.mli
@@ -733,7 +733,7 @@ val body_stream : 'a message -> stream
 val next :
   stream ->
   data:(buffer -> int -> int -> bool -> bool -> unit) ->
-  close:(unit -> unit) ->
+  close:(int -> unit) ->
   flush:(unit -> unit) ->
   ping:(unit -> unit) ->
   pong:(unit -> unit) ->

--- a/src/dream.mli
+++ b/src/dream.mli
@@ -732,7 +732,7 @@ val body_stream : 'a message -> stream
 (* TODO Argument order? *)
 val next :
   stream ->
-  data:(buffer -> int -> int -> bool -> unit) ->
+  data:(buffer -> int -> int -> bool -> bool -> unit) ->
   close:(unit -> unit) ->
   flush:(unit -> unit) ->
   ping:(unit -> unit) ->

--- a/src/http/adapt.ml
+++ b/src/http/adapt.ml
@@ -29,18 +29,27 @@ let forward_body_general
 
   let rec send () =
     Dream.body_stream response
-    |> fun stream -> Stream.read
-      stream
-      ~data
-      ~close
-      ~flush
+    |> fun stream ->
+      Stream.read
+        stream
+        ~data
+        ~close
+        ~flush
+        ~ping
+        ~pong
 
-  and data chunk off len =
+  and data chunk off len _fin =
     write_buffer ~off ~len chunk;
     send ()
 
   and flush () =
     http_flush send
+
+  and ping () =
+    send ()
+
+  and pong () =
+    send ()
 
   in
 

--- a/src/http/adapt.ml
+++ b/src/http/adapt.ml
@@ -64,7 +64,7 @@ let forward_body
     (Httpaf.Body.Writer.write_string body)
     (Httpaf.Body.Writer.write_bigstring body)
     (Httpaf.Body.Writer.flush body)
-    (fun () -> Httpaf.Body.Writer.close body)
+    (fun _code -> Httpaf.Body.Writer.close body)
 
 let forward_body_h2
     (response : Dream.response)
@@ -75,4 +75,4 @@ let forward_body_h2
     (H2.Body.write_string body)
     (H2.Body.write_bigstring body)
     (H2.Body.flush body)
-    (fun () -> H2.Body.close_writer body)
+    (fun _code -> H2.Body.close_writer body)

--- a/src/http/adapt.ml
+++ b/src/http/adapt.ml
@@ -38,7 +38,7 @@ let forward_body_general
         ~ping
         ~pong
 
-  and data chunk off len _fin =
+  and data chunk off len _binary _fin =
     write_buffer ~off ~len chunk;
     send ()
 

--- a/src/http/http.ml
+++ b/src/http/http.ml
@@ -163,11 +163,11 @@ let wrap_handler
     (* TODO Should the stream be auto-closed? It doesn't even have a closed
        state. The whole thing is just a wrapper for whatever the http/af
        behavior is. *)
-    let read ~data ~close ~flush:_ =
+    let read ~data ~close ~flush:_ ~ping:_ ~pong:_ =
       Httpaf.Body.Reader.schedule_read
         body
         ~on_eof:close
-        ~on_read:(fun buffer ~off ~len -> data buffer off len)
+        ~on_read:(fun buffer ~off ~len -> data buffer off len false)
     in
     let close () =
       Httpaf.Body.Reader.close body in
@@ -306,11 +306,11 @@ let wrap_handler_h2
 
     let body =
       H2.Reqd.request_body conn in
-    let read ~data ~close ~flush:_ =
+    let read ~data ~close ~flush:_ ~ping:_ ~pong:_ =
       H2.Body.schedule_read
         body
         ~on_eof:close
-        ~on_read:(fun buffer ~off ~len -> data buffer off len)
+        ~on_read:(fun buffer ~off ~len -> data buffer off len false)
     in
     let close () =
       H2.Body.close_reader body in

--- a/src/http/http.ml
+++ b/src/http/http.ml
@@ -156,6 +156,7 @@ let websocket_handler user's_websocket_handler socket =
   Websocketaf.Server_connection.{frame; eof}
 
 
+
 (* Wraps the user's Dream handler in the kind of handler expected by http/af.
    The scheme is simple: wait for http/af "Reqd.t"s (partially parsed
    connections), convert their fields to Dream.request, call the user's handler,

--- a/src/pure/inmost.ml
+++ b/src/pure/inmost.ml
@@ -318,6 +318,7 @@ let with_stream message =
 (* TODO Need to expose FIN. However, it can't have any effect even on
    WebSockets, because websocket/af does not offer the ability to pass FIN. It
    is hardcoded to true. *)
+(* TODO Also expose binary/text. *)
 let write message chunk =
   let promise, resolver = Lwt.wait () in
   let length = String.length chunk in
@@ -325,7 +326,7 @@ let write message chunk =
   (* TODO Better handling of close? But it can't even occur with http/af. *)
   Stream.write
     message.body
-    buffer 0 length false
+    buffer 0 length true false
     ~ok:(Lwt.wakeup_later resolver)
     ~close:(fun () -> Lwt.wakeup_later_exn resolver End_of_file);
   promise
@@ -339,9 +340,10 @@ let write_buffer ?(offset = 0) ?length message chunk =
   in
   (* TODO Proper handling of close. *)
   (* TODO As above, properly expose FIN. *)
+  (* TODO Also expose binary/text. *)
   Stream.write
     message.body
-    chunk offset length false
+    chunk offset length true false
     ~ok:(Lwt.wakeup_later resolver)
     ~close:(Lwt.wakeup_later resolver);
   promise
@@ -560,16 +562,18 @@ let websocket ?headers handler =
   in
   Lwt.return response
 
-let send ?kind:_ websocket message =
-  (* let kind =
+let send ?kind websocket message =
+  let binary =
     match kind with
-    | None | Some `Text -> `Text
-    | Some `Binary -> `Binary
-  in *)
+    | None | Some `Text -> false
+    | Some `Binary -> true
+  in
   let promise, resolver = Lwt.wait () in
   let length = String.length message in
   Stream.write
-    websocket (Bigstringaf.of_string ~off:0 ~len:length message) 0 length true
+    websocket
+    (Bigstringaf.of_string ~off:0 ~len:length message) 0 length
+    binary true
     ~ok:(Lwt.wakeup_later resolver)
     ~close:(Lwt.wakeup_later resolver);
   (* TODO The API will likely have to change to report closing. *)

--- a/src/pure/stream.ml
+++ b/src/pure/stream.ml
@@ -19,6 +19,11 @@ type read =
   pong:(unit -> unit) ->
     unit
 
+type write =
+  ok:(unit -> unit) ->
+  close:(unit -> unit) ->
+    unit
+
 type stream = {
   read : read;
 

--- a/src/pure/stream.ml
+++ b/src/pure/stream.ml
@@ -376,3 +376,23 @@ let pipe () =
   in
 
   {read; write; flush; close; ping; pong}
+
+let duplex ~read ~write ~close =
+  {
+    read = read.read;
+    write = write.write;
+    flush = write.flush;
+    ping = write.ping;
+    pong = write.pong;
+    close;
+  }
+
+let stream ~read ~write ~flush ~ping ~pong ~close =
+  {
+    read;
+    write;
+    flush;
+    ping;
+    pong;
+    close;
+  }

--- a/src/pure/stream.mli
+++ b/src/pure/stream.mli
@@ -48,7 +48,7 @@ type stream
 
 type read =
   data:(buffer -> int -> int -> bool -> bool -> unit) ->
-  close:(unit -> unit) ->
+  close:(int -> unit) ->
   flush:(unit -> unit) ->
   ping:(unit -> unit) ->
   pong:(unit -> unit) ->
@@ -59,12 +59,12 @@ type read =
 
 type write =
   ok:(unit -> unit) ->
-  close:(unit -> unit) ->
+  close:(int -> unit) ->
     unit
 (** A writing function. Pushes an event into a stream. May take additional
     arguments before [~ok]. *)
 
-val read_only : read:read -> close:(unit -> unit) -> stream
+val read_only : read:read -> close:(int -> unit) -> stream
 (** Creates a read-only stream from the given reader. [~close] is called in
     response to {!Stream.close}. It doesn't need to call {!Stream.close} again
     on the stream. It should be used to free any underlying resources. *)
@@ -82,7 +82,7 @@ val pipe : unit -> stream
     writing functions. For example, calling {!Stream.flush} on a pipe will cause
     the reader to call its [~flush] callback. *)
 
-val duplex : read:stream -> write:stream -> close:(unit -> unit) -> stream
+val duplex : read:stream -> write:stream -> close:(int -> unit) -> stream
 (** A stream whose reading functions behave like [~read], and whose writing
     functions behave like [~write]. *)
 
@@ -92,11 +92,11 @@ val stream :
   flush:write ->
   ping:write ->
   pong:write ->
-  close:(unit -> unit) ->
+  close:(int -> unit) ->
     stream
 (** A general stream. *)
 
-val close : stream -> unit
+val close : stream -> int -> unit
 (** Closes the given stream. Causes a pending reader or writer to call its
     [~close] callback. *)
 

--- a/src/pure/stream.mli
+++ b/src/pure/stream.mli
@@ -47,9 +47,11 @@ type stream
     The entire interface is pull-based for flow control. *)
 
 type read =
-  data:(buffer -> int -> int -> unit) ->
+  data:(buffer -> int -> int -> bool -> unit) ->
   close:(unit -> unit) ->
   flush:(unit -> unit) ->
+  ping:(unit -> unit) ->
+  pong:(unit -> unit) ->
     unit
 (** A reading function. Awaits the next event on the stream. For each call of a
     reading function, one of the callbacks will eventually be called, according
@@ -91,16 +93,24 @@ val read_until_close : stream -> string promise
 
 val write :
   stream ->
-  buffer -> int -> int ->
+  buffer -> int -> int -> bool ->
   ok:(unit -> unit) ->
   close:(unit -> unit) ->
     unit
 (** A writing function that sends a data buffer on the given stream. No more
     writing functions should be called on the stream until this function calls
-    [~ok]. *)
+    [~ok]. The [bool] argument is the [FIN] flag that indicates the end of a
+    WebSocket message. It is ignored by non-WebSocket streams. *)
 
-val flush :
-  stream -> ok:(unit -> unit) -> close:(unit -> unit) -> unit
+val flush : stream -> ok:(unit -> unit) -> close:(unit -> unit) -> unit
 (** A writing function that asks for the given stream to be flushed. The meaning
     of flushing depends on the implementation of the stream. No more writing
     functions should be called on the stream until this function calls [~ok]. *)
+
+val ping : stream -> ok:(unit -> unit) -> close:(unit -> unit) -> unit
+(** A writing function that sends a ping event on the given stream. This is only
+    meaningful for WebSockets. *)
+
+val pong : stream -> ok:(unit -> unit) -> close:(unit -> unit) -> unit
+(** A writing function that sends a pong event on the given stream. This is only
+    meaningful for WebSockets. *)

--- a/src/pure/stream.mli
+++ b/src/pure/stream.mli
@@ -47,7 +47,7 @@ type stream
     The entire interface is pull-based for flow control. *)
 
 type read =
-  data:(buffer -> int -> int -> bool -> unit) ->
+  data:(buffer -> int -> int -> bool -> bool -> unit) ->
   close:(unit -> unit) ->
   flush:(unit -> unit) ->
   ping:(unit -> unit) ->
@@ -88,7 +88,7 @@ val duplex : read:stream -> write:stream -> close:(unit -> unit) -> stream
 
 val stream :
   read:read ->
-  write:(buffer -> int -> int -> bool -> write) ->
+  write:(buffer -> int -> int -> bool -> bool -> write) ->
   flush:write ->
   ping:write ->
   pong:write ->
@@ -112,11 +112,11 @@ val read_until_close : stream -> string promise
 (** Reads a stream completely until [~close], and accumulates the data into a
     string. *)
 
-val write : stream -> buffer -> int -> int -> bool -> write
+val write : stream -> buffer -> int -> int -> bool -> bool -> write
 (** A writing function that sends a data buffer on the given stream. No more
     writing functions should be called on the stream until this function calls
-    [~ok]. The [bool] argument is the [FIN] flag that indicates the end of a
-    WebSocket message. It is ignored by non-WebSocket streams. *)
+    [~ok]. The [bool] arguments are whether the message is binary and whether
+    the [FIN] flag should be set. They are ignored by non-WebSocket streams. *)
 
 val flush : stream -> write
 (** A writing function that asks for the given stream to be flushed. The meaning

--- a/src/pure/stream.mli
+++ b/src/pure/stream.mli
@@ -75,6 +75,21 @@ val pipe : unit -> stream
     writing functions. For example, calling {!Stream.flush} on a pipe will cause
     the reader to call its [~flush] callback. *)
 
+val duplex : read:stream -> write:stream -> close:(unit -> unit) -> stream
+(** A stream whose reading functions behave like [~read], and whose writing
+    functions behave like [~write]. *)
+
+(* TODO Seriously fix this signature. *)
+val stream :
+  read:read ->
+  write:(buffer -> int -> int -> bool -> ok:(unit -> unit) -> close:(unit -> unit) -> unit) ->
+  flush:(ok:(unit -> unit) -> close:(unit -> unit) -> unit) ->
+  ping:(ok:(unit -> unit) -> close:(unit -> unit) -> unit) ->
+  pong:(ok:(unit -> unit) -> close:(unit -> unit) -> unit) ->
+  close:(unit -> unit) ->
+    stream
+(** A general stream. *)
+
 val close : stream -> unit
 (** Closes the given stream. Causes a pending reader or writer to call its
     [~close] callback. *)

--- a/test/expect/pure/stream/stream.ml
+++ b/test/expect/pure/stream/stream.ml
@@ -14,8 +14,8 @@ let read_and_dump stream =
     ~data:(fun buffer offset length binary fin ->
       Printf.printf "read: data: BINARY=%b FIN=%b %s\n"
         binary fin (Bigstringaf.substring buffer ~off:offset ~len:length))
-    ~close:(fun () ->
-      print_endline "read: close")
+    ~close:(fun code ->
+      Printf.printf "read: close: CODE=%i\n" code)
     ~flush:(fun () ->
       print_endline "read: flush")
     ~ping:(fun () ->
@@ -27,29 +27,29 @@ let flush_and_dump stream =
   Stream.flush stream
     ~ok:(fun () ->
       print_endline "flush: ok")
-    ~close:(fun () ->
-      print_endline "flush: close")
+    ~close:(fun code ->
+      Printf.printf "flush: close: CODE=%i\n" code)
 
 let write_and_dump stream buffer offset length binary fin =
   Stream.write stream buffer offset length binary fin
     ~ok:(fun () ->
       print_endline "write: ok")
-    ~close:(fun () ->
-      print_endline "write: close")
+    ~close:(fun code ->
+      Printf.printf "write: close: CODE=%i\n" code)
 
 let ping_and_dump stream =
   Stream.ping stream
     ~ok:(fun () ->
       print_endline "ping: ok")
-    ~close:(fun () ->
-      print_endline "ping: close")
+    ~close:(fun code ->
+      Printf.printf "ping: close: CODE=%i\n" code)
 
 let pong_and_dump stream =
   Stream.pong stream
     ~ok:(fun () ->
       print_endline "pong: ok")
-    ~close:(fun () ->
-      print_endline "pong: close")
+    ~close:(fun code ->
+      Printf.printf "pong: close: CODE=%i\n" code)
 
 
 
@@ -59,45 +59,45 @@ let%expect_test _ =
   let stream = Stream.empty in
   read_and_dump stream;
   read_and_dump stream;
-  Stream.close stream;
+  Stream.close stream 1005;
   read_and_dump stream;
   [%expect {|
-    read: close
-    read: close
-    read: close |}]
+    read: close: CODE=1000
+    read: close: CODE=1000
+    read: close: CODE=1000 |}]
 
 let%expect_test _ =
   let stream = Stream.empty in
-  Stream.close stream;
+  Stream.close stream 1005;
   read_and_dump stream;
-  [%expect {| read: close |}]
+  [%expect {| read: close: CODE=1000 |}]
 
 let%expect_test _ =
   let stream = Stream.string "foo" in
   read_and_dump stream;
   read_and_dump stream;
   read_and_dump stream;
-  Stream.close stream;
+  Stream.close stream 1005;
   read_and_dump stream;
   [%expect {|
     read: data: BINARY=true FIN=true foo
-    read: close
-    read: close
-    read: close |}]
+    read: close: CODE=1000
+    read: close: CODE=1000
+    read: close: CODE=1000 |}]
 
 let%expect_test _ =
   let stream = Stream.string "" in
   read_and_dump stream;
   read_and_dump stream;
   [%expect {|
-    read: close
-    read: close |}]
+    read: close: CODE=1000
+    read: close: CODE=1000 |}]
 
 let%expect_test _ =
   let stream = Stream.string "foo" in
-  Stream.close stream;
+  Stream.close stream 1005;
   read_and_dump stream;
-  [%expect {| read: close |}]
+  [%expect {| read: close: CODE=1000 |}]
 
 let%expect_test _ =
   let stream = Stream.empty in
@@ -134,26 +134,26 @@ let%expect_test _ =
   let stream = Stream.pipe () in
   read_and_dump stream;
   print_endline "checkpoint 1";
-  Stream.close stream;
+  Stream.close stream 1005;
   print_endline "checkpoint 2";
   read_and_dump stream;
   print_endline "checkpoint 3";
-  Stream.close stream;
+  Stream.close stream 1000;
   [%expect {|
     checkpoint 1
-    read: close
+    read: close: CODE=1005
     checkpoint 2
-    read: close
+    read: close: CODE=1005
     checkpoint 3 |}]
 
 let%expect_test _ =
   let stream = Stream.pipe () in
-  Stream.close stream;
+  Stream.close stream 1005;
   read_and_dump stream;
   read_and_dump stream;
   [%expect {|
-    read: close
-    read: close |}]
+    read: close: CODE=1005
+    read: close: CODE=1005 |}]
 
 
 
@@ -261,11 +261,11 @@ let%expect_test _ =
 let%expect_test _ =
   let stream = Stream.pipe () in
   flush_and_dump stream;
-  Stream.close stream;
+  Stream.close stream 1005;
   flush_and_dump stream;
   [%expect {|
-    flush: close
-    flush: close |}]
+    flush: close: CODE=1005
+    flush: close: CODE=1005 |}]
 
 
 
@@ -274,11 +274,11 @@ let%expect_test _ =
 let%expect_test _ =
   let stream = Stream.pipe () in
   write_and_dump stream buffer 0 3 true true;
-  Stream.close stream;
+  Stream.close stream 1005;
   write_and_dump stream buffer 0 3 true false;
   [%expect {|
-    write: close
-    write: close |}]
+    write: close: CODE=1005
+    write: close: CODE=1005 |}]
 
 
 
@@ -287,11 +287,11 @@ let%expect_test _ =
 let%expect_test _ =
   let stream = Stream.pipe () in
   ping_and_dump stream;
-  Stream.close stream;
+  Stream.close stream 1005;
   ping_and_dump stream;
   [%expect {|
-    ping: close
-    ping: close |}]
+    ping: close: CODE=1005
+    ping: close: CODE=1005 |}]
 
 
 
@@ -300,8 +300,8 @@ let%expect_test _ =
 let%expect_test _ =
   let stream = Stream.pipe () in
   pong_and_dump stream;
-  Stream.close stream;
+  Stream.close stream 1005;
   pong_and_dump stream;
   [%expect {|
-    pong: close
-    pong: close |}]
+    pong: close: CODE=1005
+    pong: close: CODE=1005 |}]

--- a/test/expect/pure/stream/stream.ml
+++ b/test/expect/pure/stream/stream.ml
@@ -11,14 +11,17 @@ module Stream = Dream__pure.Stream
 
 let read_and_dump stream =
   Stream.read stream
-    ~data:(fun buffer offset length ->
-      print_string "read: data: ";
-      Bigstringaf.substring buffer ~off:offset ~len:length
-      |> print_endline)
+    ~data:(fun buffer offset length fin ->
+      Printf.printf "read: data: FIN=%b %s\n"
+        fin (Bigstringaf.substring buffer ~off:offset ~len:length))
     ~close:(fun () ->
       print_endline "read: close")
     ~flush:(fun () ->
       print_endline "read: flush")
+    ~ping:(fun () ->
+      print_endline "read: ping")
+    ~pong:(fun () ->
+      print_endline "read: pong")
 
 let flush_and_dump stream =
   Stream.flush stream
@@ -27,12 +30,26 @@ let flush_and_dump stream =
     ~close:(fun () ->
       print_endline "flush: close")
 
-let write_and_dump stream buffer offset length =
-  Stream.write stream buffer offset length
+let write_and_dump stream buffer offset length fin =
+  Stream.write stream buffer offset length fin
     ~ok:(fun () ->
       print_endline "write: ok")
     ~close:(fun () ->
       print_endline "write: close")
+
+let ping_and_dump stream =
+  Stream.ping stream
+    ~ok:(fun () ->
+      print_endline "ping: ok")
+    ~close:(fun () ->
+      print_endline "ping: close")
+
+let pong_and_dump stream =
+  Stream.pong stream
+    ~ok:(fun () ->
+      print_endline "pong: ok")
+    ~close:(fun () ->
+      print_endline "pong: close")
 
 
 
@@ -63,7 +80,7 @@ let%expect_test _ =
   Stream.close stream;
   read_and_dump stream;
   [%expect {|
-    read: data: foo
+    read: data: FIN=true foo
     read: close
     read: close
     read: close |}]
@@ -84,13 +101,19 @@ let%expect_test _ =
 
 let%expect_test _ =
   let stream = Stream.empty in
-  (try write_and_dump stream Bigstringaf.empty 0 0
+  (try write_and_dump stream Bigstringaf.empty 0 0 false
   with Failure _ as exn -> print_endline (Printexc.to_string exn));
   (try flush_and_dump stream
   with Failure _ as exn -> print_endline (Printexc.to_string exn));
+  (try ping_and_dump stream
+  with Failure _ as exn -> print_endline (Printexc.to_string exn));
+  (try pong_and_dump stream
+  with Failure _ as exn -> print_endline (Printexc.to_string exn));
   [%expect {|
     (Failure "write to a read-only stream")
-    (Failure "flush of a read-only stream") |}]
+    (Failure "flush of a read-only stream")
+    (Failure "ping on a read-only stream")
+    (Failure "pong on a read-only stream") |}]
 
 
 
@@ -167,21 +190,69 @@ let%expect_test _ =
   let stream = Stream.pipe () in
   read_and_dump stream;
   print_endline "checkpoint 1";
-  write_and_dump stream buffer 0 3;
-  write_and_dump stream buffer 1 1;
+  write_and_dump stream buffer 0 3 true;
+  write_and_dump stream buffer 1 1 false;
   print_endline "checkpoint 2";
   read_and_dump stream;
-  write_and_dump stream buffer 0 3;
-  try write_and_dump stream buffer 0 3
+  write_and_dump stream buffer 0 3 true;
+  try write_and_dump stream buffer 0 3 false
   with Failure _ as exn -> print_endline (Printexc.to_string exn);
   [%expect {|
     checkpoint 1
-    read: data: foo
+    read: data: FIN=true foo
     write: ok
     checkpoint 2
-    read: data: o
+    read: data: FIN=false o
     write: ok
     (Failure "stream write: the previous write has not completed") |}]
+
+
+
+(* Pipe: interactions between read and ping. *)
+
+let%expect_test _ =
+  let stream = Stream.pipe () in
+  read_and_dump stream;
+  print_endline "checkpoint 1";
+  ping_and_dump stream;
+  ping_and_dump stream;
+  print_endline "checkpoint 2";
+  read_and_dump stream;
+  ping_and_dump stream;
+  try ping_and_dump stream
+  with Failure _ as exn -> print_endline (Printexc.to_string exn);
+  [%expect {|
+    checkpoint 1
+    read: ping
+    ping: ok
+    checkpoint 2
+    read: ping
+    ping: ok
+    (Failure "stream ping: the previous write has not completed") |}]
+
+
+
+(* Pipe: interactions between read and pong. *)
+
+let%expect_test _ =
+  let stream = Stream.pipe () in
+  read_and_dump stream;
+  print_endline "checkpoint 1";
+  pong_and_dump stream;
+  pong_and_dump stream;
+  print_endline "checkpoint 2";
+  read_and_dump stream;
+  pong_and_dump stream;
+  try pong_and_dump stream
+  with Failure _ as exn -> print_endline (Printexc.to_string exn);
+  [%expect {|
+    checkpoint 1
+    read: pong
+    pong: ok
+    checkpoint 2
+    read: pong
+    pong: ok
+    (Failure "stream pong: the previous write has not completed") |}]
 
 
 
@@ -202,9 +273,35 @@ let%expect_test _ =
 
 let%expect_test _ =
   let stream = Stream.pipe () in
-  write_and_dump stream buffer 0 3;
+  write_and_dump stream buffer 0 3 true;
   Stream.close stream;
-  write_and_dump stream buffer 0 3;
+  write_and_dump stream buffer 0 3 false;
   [%expect {|
     write: close
     write: close |}]
+
+
+
+(* Pipe: interactions between ping and close. *)
+
+let%expect_test _ =
+  let stream = Stream.pipe () in
+  ping_and_dump stream;
+  Stream.close stream;
+  ping_and_dump stream;
+  [%expect {|
+    ping: close
+    ping: close |}]
+
+
+
+(* Pipe: interactions between pong and close. *)
+
+let%expect_test _ =
+  let stream = Stream.pipe () in
+  pong_and_dump stream;
+  Stream.close stream;
+  pong_and_dump stream;
+  [%expect {|
+    pong: close
+    pong: close |}]


### PR DESCRIPTION
Apart from changing the underlying abstraction, this also:

- Removes the push-oriented ("read as fast sa possible") WebSocket reader and replaces it with a more pull-oriented reader, to the greatest extent possible with current websocket/af (AFAIK it is not possible to get fully pull-only reading right now). This prevents (or, right now, greatly limits) buffer accumulation in the reader (server), which is a security issue.
- Exposes the `FIN` bit, ping and pong frames, and receiving the text/binary message flag to the Dream user (when using the lowest-level stream APIs; high-level convenience APIs don't still hide this). Receiving the text/binary bit is usually not relevant for the server, but may be relevant for some native clients that are not using UTF-8 for whatever reason.

The Dream API is largely unchanged, it is just reimplemented using Stream. The API will be tweaked in follow-on PRs.