### PR TITLE
Primitive HTTP write backpressure

### DIFF
--- a/example/w-stress-response/README.md
+++ b/example/w-stress-response/README.md
@@ -10,19 +10,16 @@ by default. To use,
 <b>$ npx esy start</b>
 <b>$ curl http://localhost:8080 > /dev/null &</b></code></pre>
 
-The `curl` command can be repeated for multiple concurrent clients.
+The `curl` command can be repeated for multiple concurrent clients, to check
+fairness or other effects.
+
+The URL supports query parameters: `?mb=16384` sets the total number of
+megabytes to respond with (16 GB in this case), and `?chunk=128` changes the
+chunk size used during writing (128 KB in this case).
 
 <br>
 
-Writing currently slows down for very large streams. This is likely due to the
-lack of server-side flow control for writers, which probably causes allocation
-of huge internal buffers, which first triggers needless GC, and eventually page
-thrashing at the virtual memory level.
-[#34](https://github.com/aantron/dream/issues/34) should address this in one of
-the early releases of Dream.
-
-Nonetheless, for smaller streams, unoptimized Dream is able to peak out at
-about 8 Gbits/s, which is more than one curl client can handle (2 Gbits/s).
+Dream is currently able to peak out on my machine at about 10 Gbit/s.
 
 <br>
 

--- a/example/w-stress-response/stress_response.ml
+++ b/example/w-stress-response/stress_response.ml
@@ -1,8 +1,8 @@
-(* TODO Once concurrent writing is supported, send N concurrent streams and test
-   for fairness. *)
-(* TODO There seems to be some GC thrashing and even page thrashing or similar
-   with very large streams, probably due to buffer growth from a lack of
-   server-side flow control. *)
+let show_heap_size () =
+  Gc.((quick_stat ()).heap_words) * 8
+  |> float_of_int
+  |> fun bytes -> bytes /. 1024. /. 1024.
+  |> Dream.log "Heap size: %.0f MB"
 
 let stress ?(megabytes = 1024) ?(chunk = 64) response =
   let limit = megabytes * 1024 * 1024 in
@@ -28,6 +28,7 @@ let stress ?(megabytes = 1024) ?(chunk = 64) response =
 
   Dream.log "%.0f MB/s over %.1f s"
     ((float_of_int megabytes) /. elapsed) elapsed;
+  show_heap_size ();
 
   Lwt.return_unit
 
@@ -35,6 +36,8 @@ let query_int name request =
   Dream.query name request |> Option.map int_of_string
 
 let () =
+  show_heap_size ();
+
   Dream.run
   @@ Dream.logger
   @@ Dream.router [


### PR DESCRIPTION
Part of #27.

This change makes Dream wait to give the peer a chance to receive data (as it should). Dream now uses a constant amount of memory per response stream, limited by the size of the largest single buffer sent by the Dream user for streaming out. This also greatly reduces allocations, which in turn speeds speeds performance on large streams by 3-4x. Dream also no longer runs out of memory on huge streams, since it does not flood its internal buffers faster than the client can receive data.

There may be other ways to interleave flushes and callback calls, better flush intervals to choose, etc.