### PR TITLE
Primitive WebSocket send backpressure

### DIFF
--- a/example/w-stress-websocket-send/README.md
+++ b/example/w-stress-websocket-send/README.md
@@ -5,15 +5,8 @@
 This example serves a client which opens four WebSockets. The server then floods
 each WebSocket with 1 GB of data in 64 KB one-frame messages.
 
-At the moment, the naive and unoptimized Dream massively outpaces Chrome. Dream
-sends the 4 GB in about 8 seconds, at a resulting speed of about 4 Gbits/s.
-Chrome appears to receive all the messages, but the JavaScript engine processes
-them in about 10 minutes (55 Mbit/s), causing massive buffering in Chrome.
-
-This test should be improved after flow control is added internally to Dream's
-writers in [#34](https://github.com/aantron/dream/issues/34). It should probably
-be run with multiple separate client tabs or processes, rather than one
-JavaScript context.
+At the moment, Dream greatly outpaces Chrome, which appears to limit WebSocket
+traffic to 64 MB/s per tab.
 
 <br>
 

--- a/example/w-stress-websocket-send/stress_websocket_send.eml.ml
+++ b/example/w-stress-websocket-send/stress_websocket_send.eml.ml
@@ -26,6 +26,12 @@ let home =
     </body>
   </html>
 
+let show_heap_size () =
+  Gc.((quick_stat ()).heap_words) * 8
+  |> float_of_int
+  |> fun bytes -> bytes /. 1024. /. 1024.
+  |> Dream.log "Heap size: %.0f MB"
+
 let frame = 64 * 1024
 
 let frame_a = String.make frame 'a'
@@ -48,10 +54,13 @@ let stress websocket =
 
   Dream.log "%.0f MB/s over %.1f s"
     ((float_of_int limit) /. elapsed /. 1024. /. 1024.) elapsed;
+  show_heap_size ();
 
   Lwt.return_unit
 
 let () =
+  show_heap_size ();
+
   Dream.run
   @@ Dream.logger
   @@ Dream.router [


### PR DESCRIPTION
Same as #179, but for WebSockets.

After this PR, Dream has backpressure in all directions: HTTP read, HTTP write, WebSocket send, and WebSocket receive.

Fixes #27.