### PR TITLE
Move dependencies of dream-pure to that module

### DIFF
--- a/dream-pure.opam
+++ b/dream-pure.opam
@@ -18,9 +18,11 @@ depends: [
   "dune" {>= "2.7.0"}  # --instrument-with.
   "hmap"
   "lwt"
+  "lwt_ppx" {>= "1.2.2"}
   "ocaml" {>= "4.08.0"}
   "ptime" {>= "0.8.1"}  # Ptime.weekday.
   "uri" {>= "4.2.0"}
+  "multipart_form" {>= "0.3.0"}
 
   # Testing, development.
   "alcotest" {with-test}

--- a/dream-pure.opam
+++ b/dream-pure.opam
@@ -22,7 +22,6 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "ptime" {>= "0.8.1"}  # Ptime.weekday.
   "uri" {>= "4.2.0"}
-  "multipart_form" {>= "0.3.0"}
 
   # Testing, development.
   "alcotest" {with-test}

--- a/dream.opam
+++ b/dream.opam
@@ -60,14 +60,12 @@ depends: [
   "graphql_parser"
   "graphql-lwt"
   "lwt"
-  "lwt_ppx" {>= "1.2.2"}
   "lwt_ssl"
   "logs" {>= "0.5.0"}
   "magic-mime"
   "mirage-clock"
   "mirage-crypto" {>= "0.8.1"}  # AES-256-GCM.
   "mirage-crypto-rng" {>= "0.8.0"}  # Signature of initialize.
-  "multipart_form" {>= "0.3.0"}
   "ocaml" {>= "4.08.0"}
   "ptime" {>= "0.8.1"}  # Ptime.v.
   "ssl" {>= "0.5.8"}  # Ssl.get_negotiated_alpn_protocol.

--- a/dream.opam
+++ b/dream.opam
@@ -66,6 +66,7 @@ depends: [
   "mirage-clock"
   "mirage-crypto" {>= "0.8.1"}  # AES-256-GCM.
   "mirage-crypto-rng" {>= "0.8.0"}  # Signature of initialize.
+  "multipart_form" {>= "0.3.0"}
   "ocaml" {>= "4.08.0"}
   "ptime" {>= "0.8.1"}  # Ptime.v.
   "ssl" {>= "0.5.8"}  # Ssl.get_negotiated_alpn_protocol.

--- a/dream.opam
+++ b/dream.opam
@@ -60,6 +60,7 @@ depends: [
   "graphql_parser"
   "graphql-lwt"
   "lwt"
+  "lwt_ppx" {>= "1.2.2"}
   "lwt_ssl"
   "logs" {>= "0.5.0"}
   "magic-mime"


### PR DESCRIPTION
This was necessary for me to use Dream from git with esy because was complaining about missing dependencies in dream-pure otherwise (quite reasonably from what I can tell).