### PR TITLE
Add camlp-streams dep for 5.0.0

### DIFF
--- a/dream.opam
+++ b/dream.opam
@@ -49,6 +49,7 @@ maintainer: "Anton Bachin <antonbachin@yahoo.com>"
 depends: [
   "base-unix"
   "bigarray-compat"
+  "camlp-streams"
   "caqti" {>= "1.6.0"}  # https://github.com/aantron/dream/issues/44.
   "caqti-lwt"
   "conf-libev" {os != "win32"}

--- a/src/eml/dune
+++ b/src/eml/dune
@@ -9,4 +9,5 @@
 (library
  (name eml)
  (modules eml)
+ (libraries camlp-streams)
  (instrumentation (backend bisect_ppx)))


### PR DESCRIPTION
This PR adds a dependency on [camlp-streams](https://github.com/ocaml/camlp-streams) after `Stream` was removed from standard library of the compiler for OCaml 5. This fixes #208. 