### PR TITLE
docs: Remove unnecessary `@@ Dream.not_found` from code sample

### DIFF
--- a/docs/web/templates/index.html
+++ b/docs/web/templates/index.html
@@ -52,8 +52,7 @@
   @@ <span class="hljs-type">Dream</span>.router <span class="hljs-string">[</span>
     <span class="hljs-type">Dream</span>.get <span class="hljs-string">"/"</span> (<span class="keyword">fun</span> _ ->
       <span class="hljs-type">Dream</span>.html (hello <span class="hljs-string">"world"</span>));
-  <span class="hljs-string">]</span>
-  @@ <span class="hljs-type">Dream</span>.not_found</pre>
+  <span class="hljs-string">]</span></pre>
 
   <!-- Send TLS link to HTTPS example. -->
 


### PR DESCRIPTION
It doesn't seem to be necessary anymore, since `Dream.router` returns a handler, not a middleware.