### PR TITLE
Fix build failure due to label warning

### DIFF
--- a/example/w-fullstack-rescript/README.md
+++ b/example/w-fullstack-rescript/README.md
@@ -58,7 +58,7 @@ let () = {
 
     let p = document |> Document.createElement("p")
     p->Element.setInnerText(text)
-    body |> Element.appendChild(p)
+    body |> Element.appendChild(~child=p)
   }
 }
 ```

--- a/example/w-fullstack-rescript/client/client.res
+++ b/example/w-fullstack-rescript/client/client.res
@@ -3,14 +3,13 @@ open Webapi.Dom
 let () = {
   let body = document->Document.querySelector("body")
 
-  switch (body) {
+  switch body {
   | None => ()
   | Some(body) =>
-
     let text = Common.greet(#Client)
 
     let p = document->Document.createElement("p")
     p->Element.setInnerText(text)
-    body->Element.appendChild(p)
+    body->Element.appendChild(~child=p)
   }
 }

--- a/example/w-fullstack-rescript/package.json
+++ b/example/w-fullstack-rescript/package.json
@@ -4,7 +4,7 @@
     "esbuild": "*",
     "esy": "*",
     "rescript": "*",
-    "rescript-webapi": "*"
+    "rescript-webapi": "^0.5.0"
   },
   "scripts": {
     "postinstall": "npx esy install",


### PR DESCRIPTION
Compilation fails due to unlabeled argument `p`

```
rescript: [6/6] client/client.cmj
FAILED: client/client.cmj

  Warning number 6 (configured as error)
  .../dream/example/w-fullstack-rescript/client/client.res:14:11-29

  12 │     let p = document->Document.createElement("p")
  13 │     p->Element.setInnerText(text)
  14 │     body->Element.appendChild(p)
  15 │   }
  16 │ }

  label child was omitted in the application of this function.
```