### PR TITLE
add stdout as output from dream_eml

### DIFF
--- a/src/eml/eml.ml
+++ b/src/eml/eml.ml
@@ -782,7 +782,7 @@ end
 
 
 
-let process_file (input_file, location, syntax) =
+let process_file (input_file, location, syntax, std_out) =
   let reason, extension = match syntax with
   | `OCaml -> (false, ".ml")
   | `Reason -> (true, ".re")
@@ -800,7 +800,7 @@ let process_file (input_file, location, syntax) =
   (* We don't bother closing these - the OCaml runtime and/or kernel will close
      it automatically on process exit, anyway. *)
   let input_channel = open_in input_file in
-  let output_channel = open_out output_file in
+  let output_channel = if std_out then stdout else open_out output_file in
 
   let input_stream = Location.stream (fun () ->
     try Some (input_char input_channel)

--- a/src/eml/main.ml
+++ b/src/eml/main.ml
@@ -7,7 +7,7 @@
 
 module Command_line :
 sig
-  val parse : unit -> (string * string * [ `OCaml | `Reason ]) list
+  val parse : unit -> (string * string * [ `OCaml | `Reason ] * bool) list
 end =
 struct
   let usage = {|Usage:
@@ -24,6 +24,9 @@ struct
   let emit_reason =
     ref false
 
+  let std_out = 
+    ref false
+
   let options = Arg.align [
     "--workspace",
     Arg.Set_string workspace_path,
@@ -31,6 +34,9 @@ struct
     "--emit-reason",
     Arg.Set emit_reason,
     " Emit Reason syntax after preprocessing the template";
+    "--stdout",
+    Arg.Set std_out,
+    " Print to STDOUT";
   ]
 
   let set_file file =
@@ -71,7 +77,7 @@ struct
         | ".re" -> `Reason
         | _ -> `OCaml
       in
-      file, Filename.concat prefix file, syntax)
+      file, Filename.concat prefix file, syntax, !std_out)
 end
 
 let () =


### PR DESCRIPTION
quick and dirty implementation for #227 

this should work with this `dialect` in `dune-project`

```
(dialect
 (name eml)
 (implementation
  (extension eml)
  (preprocess (run ./main.exe --stdout %{input-file})))
 (interface
  (extension emli)
  (format (run cat)))
 )
```

I only tested this very briefly but it seems to work fine. I think the `interface` stanza is required, but that will never been needed I guess?

If this is something that is worth doing, let me know and then I can maybe look into rewriting some examples as well to use the dialect?