### PR TITLE
Point to patched ocaml-h2.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/aantron/websocketaf.git
 [submodule "src/vendor/h2"]
 	path = src/vendor/h2
-	url = https://github.com/aantron/ocaml-h2.git
+	url = https://github.com/novemberkilo/ocaml-h2.git
 [submodule "src/vendor/paf"]
 	path = src/vendor/paf
 	url = https://github.com/dinosaure/paf-le-chien.git


### PR DESCRIPTION
Hi - this follows from working on getting `dream` to build on OCaml 5.

Please see [this build failure](http://check.ocamllabs.io/log/1666790526-445ff10841f25868d96c33b756783bfa4ceb4f44/5.0+alpha-repo/partial/dream.1.0.0~alpha4) -- essentially we need a patch on `httpaf` which in turn needs a patch on `h2` to fix the build.
 
Currently pointing h2 to my fork of it that builds on OCaml 5. 

Will update once https://github.com/aantron/ocaml-h2/pull/1 is merged.