### PR TITLE
Add dependency on rresult.

### DIFF
--- a/dream-mirage.opam
+++ b/dream-mirage.opam
@@ -61,9 +61,9 @@ depends: [
   "lwt_ppx" {>= "1.2.2"}
   "mimic"
   "mirage-time"
+  "rresult"
   "tcpip"
   "tls-mirage"
-  "rresult"
 ]
 
 build: [

--- a/dream-mirage.opam
+++ b/dream-mirage.opam
@@ -63,6 +63,7 @@ depends: [
   "mirage-time"
   "tcpip"
   "tls-mirage"
+  "rresult"
 ]
 
 build: [

--- a/src/mirage/dune
+++ b/src/mirage/dune
@@ -5,13 +5,13 @@
   bigarray-compat
   bigstringaf
   digestif
-  rresult
   dream.cipher
   dream.server
   dream.certificate
   dream-pure
   dream-httpaf.dream-h2
   lwt
+  rresult
   tcpip
   dream-mirage.dream-paf
   dream-mirage.dream-paf.alpn

--- a/src/mirage/dune
+++ b/src/mirage/dune
@@ -5,6 +5,7 @@
   bigarray-compat
   bigstringaf
   digestif
+  rresult
   dream.cipher
   dream.server
   dream.certificate


### PR DESCRIPTION
Missing dependency on `rresult` in the `dream-mirage` library.

https://github.com/aantron/dream/blob/master/src/mirage/mirage.ml#L20