### PR TITLE
Get the Windows CI working

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,6 @@ jobs:
           ocaml: 4.12.x
         - os: windows-latest
           ocaml: 4.14.x
-        # Windows is blocked until we no longer require libev; Dream still works
-        # on Windows, but testing it is awkward at the moment.
 
     runs-on: ${{matrix.os}}
     steps:
@@ -44,13 +42,16 @@ jobs:
           opam-repository-mingw: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
           default: https://github.com/ocaml/opam-repository.git
 
+    - run: opam depext --yes conf-sqlite3
     - run: opam depext --yes conf-postgresql
     - run: opam depext --yes conf-libev
+      if: runner.os != 'Windows'
 
     # The tests require ppx_expect. The latest versions of it introduced changes
     # in the formatting of the output, and also require OCaml >= 4.10, which
     # makes testing on < 4.10 awkward. So, we skip tests on < 4.10.
-    - run: |
+    - shell: bash
+      run: |
         set -e
         set -x
 
@@ -60,11 +61,17 @@ jobs:
           4.08.x) WITH_TEST=;;
         esac
 
-        opam install --yes --deps-only $WITH_TEST ./dream-pure.opam ./dream-httpaf.opam ./dream.opam
+        OPAM=$(which opam || true)
+        if [ -z "$OPAM" ]
+        then
+          OPAM=D:\\cygwin\\wrapperbin\\opam.cmd
+        fi
+
+        $OPAM install --yes --deps-only $WITH_TEST ./dream-pure.opam ./dream-httpaf.opam ./dream.opam
 
         if [ ! -z "$WITH_TEST" ]
         then
-          opam exec -- dune runtest
+          $OPAM exec -- dune runtest
 
           EXAMPLES=$(find example -maxdepth 1 -type d -not -name "w-mirage*" -not -name "r-tyxml" | grep -v "^example/0" | grep -v "^example$" | sort)
           shopt -s nullglob
@@ -74,7 +81,7 @@ jobs:
             FILE=$(ls $EXAMPLE/*.ml $EXAMPLE/*.re $EXAMPLE/server/*.ml $EXAMPLE/server/*.re)
             EXE=$(echo $FILE | sed 's/\..*$/.exe/g')
             echo dune build $EXE
-            opam exec -- dune build $EXE
+            $OPAM exec -- dune build $EXE
           done
         fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
         include:
         - os: macos-latest
           ocaml: 4.12.x
+        - os: windows-latest
+          ocaml: 4.14.x
         # Windows is blocked until we no longer require libev; Dream still works
         # on Windows, but testing it is awkward at the moment.
 
@@ -30,8 +32,17 @@ jobs:
         submodules: recursive
 
     - uses: avsm/setup-ocaml@v2
+      if: runner.os != 'Windows'
       with:
         ocaml-compiler: ${{matrix.ocaml}}
+
+    - uses: avsm/setup-ocaml@v2
+      if: runner.os == 'Windows'
+      with:
+        ocaml-compiler: ${{matrix.ocaml}}
+        opam-repositories: |
+          opam-repository-mingw: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
+          default: https://github.com/ocaml/opam-repository.git
 
     - run: opam depext --yes conf-postgresql
     - run: opam depext --yes conf-libev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,12 @@ jobs:
           4.08.x) WITH_TEST=;;
         esac
 
+        # Tests on Windows are disabled because of a difference in ppx_expect
+        # output. See https://github.com/aantron/dream/pull/282.
+        case ${{runner.os}} in
+          Windows) WITH_TEST=;;
+        esac
+
         OPAM=$(which opam || true)
         if [ -z "$OPAM" ]
         then

--- a/dream.opam
+++ b/dream.opam
@@ -52,7 +52,7 @@ depends: [
   "camlp-streams"
   "caqti" {>= "1.8.0"}  # Infix operators.
   "caqti-lwt"
-  "conf-libev" {os != "win32"}
+  ("conf-libev" {os != "win32"} | "ocaml" {os = "win32"})
   "cstruct" {>= "6.0.0"}
   "dream-httpaf" {>= "1.0.0~alpha2"}
   "dream-pure" {>= "1.0.0~alpha2"}


### PR DESCRIPTION
There appears to be a difference in ppx_expect 0.15.1 output between Windows and Linux. A typical diff looks like this:

```diff
-  [%expect {|
-    (1, 0) Code_block
-    let foo =
-      bar |}]
+  [%expect {|(1, 0) Code_block
+let foo =
+  bar |}]
```

This can be seen in the CI run for this branch [here](https://github.com/aantron/dream/actions/runs/4976899776/jobs/8905385127#step:8:410). Both the [Windows](https://github.com/aantron/dream/actions/runs/4976899776/jobs/8905385127#step:8:382) and the [Linux](https://github.com/aantron/dream/actions/runs/4976899776/jobs/8905384575#step:8:174) are installing ppx_expect 0.15.1. Both are running on OCaml 4.14.1. @hhugo do you know what could be causing this? Should I report it upstream at ppx_expect?