### PR TITLE
Minor dream-mirage fixes

### DIFF
--- a/dream-mirage.opam
+++ b/dream-mirage.opam
@@ -59,7 +59,7 @@ depends: [
   "letsencrypt" {>= "0.3.0"}
   "lwt"
   "lwt_ppx" {>= "1.2.2"}
-  "mimic" {>= "0.0.6"}
+  "mimic" {>= "0.0.4"}
   "mirage-time"
   "rresult"
   "tcpip"

--- a/dream-mirage.opam
+++ b/dream-mirage.opam
@@ -59,7 +59,7 @@ depends: [
   "letsencrypt" {>= "0.3.0"}
   "lwt"
   "lwt_ppx" {>= "1.2.2"}
-  "mimic"
+  "mimic" {>= "0.0.6"}
   "mirage-time"
   "rresult"
   "tcpip"

--- a/dream-mirage.opam
+++ b/dream-mirage.opam
@@ -59,7 +59,7 @@ depends: [
   "letsencrypt" {>= "0.3.0"}
   "lwt"
   "lwt_ppx" {>= "1.2.2"}
-  "mimic" {>= "0.0.4"}
+  "mimic" {>= "0.0.5"}
   "mirage-time"
   "rresult"
   "tcpip"

--- a/dream.opam
+++ b/dream.opam
@@ -61,7 +61,7 @@ depends: [
   "graphql_parser"
   "graphql-lwt"
   "lwt"
-  "lwt_ppx" {>= "2.1.0"}
+  "lwt_ppx" {>= "1.2.2"}
   "lwt_ssl"
   "logs" {>= "0.5.0"}
   "magic-mime"

--- a/dream.opam
+++ b/dream.opam
@@ -61,7 +61,7 @@ depends: [
   "graphql_parser"
   "graphql-lwt"
   "lwt"
-  "lwt_ppx" {>= "1.2.2"}
+  "lwt_ppx" {>= "2.1.0"}
   "lwt_ssl"
   "logs" {>= "0.5.0"}
   "magic-mime"

--- a/src/mirage/mirage.ml
+++ b/src/mirage/mirage.ml
@@ -343,13 +343,6 @@ module Make (Pclock : Mirage_clock.PCLOCK) (Time : Mirage_time.S) (Stack : Tcpip
   let verify_csrf_token = verify_csrf_token ~now
   let csrf_tag = Tag.csrf_tag ~now
 
-  (* Templates *)
-
-  let form_tag ?method_ ?target ?enctype ?csrf_token ~action request =
-    Tag.form_tag ~now ?method_ ?target ?enctype ?csrf_token ~action request
-
-
-
   (* Errors *)
 
   type error = Catch.error = {


### PR DESCRIPTION
The doc changes try to mirror the organisation in `dream.mli` as closely a possible. 
As a follow up PR I can re-organise `dream-mirage` to exactly mirror the main `dream` docs. 
It would be helpful for them to be in sync and it makes it easier to see what has changed when diffing dream and dream-mirage. What do you think @aantron ?