### PR TITLE
Fix broken JSON example

### DIFF
--- a/example/e-json/README.md
+++ b/example/e-json/README.md
@@ -10,6 +10,9 @@ converter between JSON and an OCaml data type. We then create a little server
 that listens for JSON of the right shape, and echoes back its `message` field:
 
 ```ocaml
+(* Bring the Yojson-converters for primitive types into scope *)
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
 type message_object = {
   message : string;
 } [@@deriving yojson]

--- a/example/e-json/README.md
+++ b/example/e-json/README.md
@@ -10,7 +10,6 @@ converter between JSON and an OCaml data type. We then create a little server
 that listens for JSON of the right shape, and echoes back its `message` field:
 
 ```ocaml
-(* Bring the Yojson-converters for primitive types into scope *)
 open Ppx_yojson_conv_lib.Yojson_conv.Primitives
 
 type message_object = {

--- a/example/e-json/json.ml
+++ b/example/e-json/json.ml
@@ -1,3 +1,6 @@
+(* Bring the Yojson-converters for primitive types into scope *)
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
 type message_object = {
   message : string;
 } [@@deriving yojson]

--- a/example/e-json/json.ml
+++ b/example/e-json/json.ml
@@ -1,4 +1,3 @@
-(* Bring the Yojson-converters for primitive types into scope *)
 open Ppx_yojson_conv_lib.Yojson_conv.Primitives
 
 type message_object = {


### PR DESCRIPTION
Per the instructions given at: 

https://github.com/janestreet/ppx_yojson_conv

> Note that Yojson-converters for primitive types like int need to be brought into scope in order for the ppx to use them, for example by adding open
  Ppx_yojson_conv_lib.Yojson_conv.Primitives at the beginning of the file.