### PR TITLE
chore(dream): re-export dream-pure library

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -9,7 +9,7 @@
   dream.http
   dream.server
   dream.unix
-  dream-pure
+  (re_export dream-pure)
   dream.sql
   fmt.tty
   graphql-lwt


### PR DESCRIPTION
Using the template preprocessor  assumes `dream-pure` is re-exported, which it won't be if `implicit_transitive_deps` is disabled in the consuming project, unless the library is explicitly re-exported. This does that.

For more information:
- [Documentation for `re_export`](https://dune.readthedocs.io/en/stable/reference/library-dependencies.html#re-exported-dependencies)
- [Documentation for `implicit_transitive_deps`](https://dune.readthedocs.io/en/stable/dune-files.html#implicit-transitive-deps)
- [An example of someone likely tripping over this on Stack Overflow](https://stackoverflow.com/q/76750178/7943564)