### PR TITLE
example/z-docker-opam: update alpine version

### DIFF
--- a/example/z-docker-opam/Dockerfile
+++ b/example/z-docker-opam/Dockerfile
@@ -15,7 +15,7 @@ RUN opam exec -- dune build
 
 
 
-FROM alpine:3.12 as run
+FROM alpine:3.18.4 as run
 
 RUN apk add --update libev
 


### PR DESCRIPTION
I've encountered this issue #275 related to `z-docker-opam` example when first tried to run it locally.

I saw this `Error loading shared library libssl.so.3: No such file or directory (needed by /bin/app)` on Mac M1, also on Windows and WSL with Ubuntu.

Update the alpine version from `3.12` to the most recent `3.18.4` had solved things here on all 3 environments (removing the `LOGGING_DRIVER` variable from `deploy.sh`).