### PR TITLE
Upgrade Caqti to 2.0.1

### DIFF
--- a/dream.opam
+++ b/dream.opam
@@ -50,8 +50,8 @@ depends: [
   "base-unix"
   "bigarray-compat"
   "camlp-streams"
-  "caqti" {>= "1.8.0"}  # Infix operators.
-  "caqti-lwt"
+  "caqti" {>= "2.0.1"}
+  "caqti-lwt" {>= "2.0.1"}
   ("conf-libev" {os != "win32"} | "ocaml" {os = "win32"})
   "cstruct" {>= "6.0.0"}
   "dream-httpaf" {>= "1.0.0~alpha2"}

--- a/dream.opam
+++ b/dream.opam
@@ -50,8 +50,8 @@ depends: [
   "base-unix"
   "bigarray-compat"
   "camlp-streams"
-  "caqti" {>= "2.0.1"}
-  "caqti-lwt" {>= "2.0.1"}
+  "caqti" {>= "2.0.0"}
+  "caqti-lwt" {>= "2.0.0"}
   ("conf-libev" {os != "win32"} | "ocaml" {os = "win32"})
   "cstruct" {>= "6.0.0"}
   "dream-httpaf" {>= "1.0.0~alpha2"}

--- a/example/h-sql/sql.eml.ml
+++ b/example/h-sql/sql.eml.ml
@@ -4,7 +4,7 @@ module T = Caqti_type
 let list_comments =
   let query =
     let open Caqti_request.Infix in
-    (T.unit ->* T.(tup2 int string))
+    (T.unit ->* T.(t2 int string))
     "SELECT id, text FROM comment" in
   fun (module Db : DB) ->
     let%lwt comments_or_error = Db.collect_list query () in

--- a/example/w-postgres/postgres.eml.ml
+++ b/example/w-postgres/postgres.eml.ml
@@ -5,7 +5,7 @@ module T = Caqti_type
 let list_comments =
   let query =
     let open Caqti_request.Infix in
-    (T.unit ->* T.(tup2 int string))
+    (T.unit ->* T.(t2 int string))
     "SELECT id, text FROM comment" in
   fun (module Db : DB) ->
     let%lwt comments_or_error = Db.collect_list query () in

--- a/src/sql/dune
+++ b/src/sql/dune
@@ -4,6 +4,7 @@
  (libraries
   caqti
   caqti-lwt
+  caqti-lwt.unix
   dream.cipher
   dream-pure
   dream.server

--- a/src/sql/session.ml
+++ b/src/sql/session.ml
@@ -28,7 +28,7 @@ let serialize_payload payload =
 let insert =
   let query =
     let open Caqti_request.Infix in
-    (T.(tup4 string string float string) ->. T.unit) {|
+    (T.(t4 string string float string) ->. T.unit) {|
       INSERT INTO dream_session (id, label, expires_at, payload)
       VALUES ($1, $2, $3, $4)
     |} in
@@ -42,7 +42,7 @@ let insert =
 let find_opt =
   let query =
     let open Caqti_request.Infix in
-    (T.string ->? T.(tup3 string float string))
+    (T.string ->? T.(t3 string float string))
       "SELECT label, expires_at, payload FROM dream_session WHERE id = $1" in
 
   fun (module Db : DB) id ->
@@ -70,7 +70,7 @@ let find_opt =
 let refresh =
   let query =
     let open Caqti_request.Infix in
-    (T.(tup2 float string) ->. T.unit)
+    (T.(t2 float string) ->. T.unit)
       "UPDATE dream_session SET expires_at = $1 WHERE id = $2" in
 
   fun (module Db : DB) (session : Session.session) ->
@@ -80,7 +80,7 @@ let refresh =
 let update =
   let query =
     let open Caqti_request.Infix in
-    (T.(tup2 string string) ->. T.unit)
+    (T.(t2 string string) ->. T.unit)
       "UPDATE dream_session SET payload = $1 WHERE id = $2" in
 
   fun (module Db : DB) (session : Session.session) ->

--- a/src/sql/sql.ml
+++ b/src/sql/sql.ml
@@ -14,7 +14,7 @@ let log =
   Log.sub_log "dream.sql"
 
 (* TODO Debug metadata for the pools. *)
-let pool_field : (_, Caqti_error.t) Caqti_lwt.Pool.t Message.field =
+let pool_field : (_, Caqti_error.t) Caqti_lwt_unix.Pool.t Message.field =
   Message.new_field ()
 
 (* TODO This may not be necessary since Caqti 1.8.0. May require some messing
@@ -48,7 +48,8 @@ let sql_pool ?size uri =
         "Dream.sql_pool: \
         'sqlite' is not a valid scheme; did you mean 'sqlite3'?");
     let pool =
-      Caqti_lwt.connect_pool ?max_size:size ~post_connect parsed_uri in
+      let pool_config = Caqti_pool_config.create ?max_size:size () in
+      Caqti_lwt_unix.connect_pool ~pool_config ~post_connect parsed_uri in
     match pool with
     | Ok pool ->
       pool_cell := Some pool;
@@ -72,7 +73,7 @@ let sql request callback =
     failwith message
   | Some pool ->
     let%lwt result =
-      pool |> Caqti_lwt.Pool.use (fun db ->
+      pool |> Caqti_lwt_unix.Pool.use (fun db ->
         (* The special exception handling is a workaround for
            https://github.com/paurkedal/ocaml-caqti/issues/68. *)
         match%lwt callback db with


### PR DESCRIPTION
Caqti 2 includes some breaking changes, so I'm proposing this upgrade. To run the test suite I had comment out `Mirage.form_tag` and disable the z-playground example, which is of course not included in this PR.