### PR TITLE
Fix typo in doc of Dream.router

### DIFF
--- a/src/dream.mli
+++ b/src/dream.mli
@@ -1368,7 +1368,7 @@ val router : route list -> handler
         Dream.run
         @@ Dream.router [
           Dream.get "/echo/:word" @@ fun request ->
-            Dream.html (Dream.param "word" request);
+            Dream.html (Dream.param request "word");
         ]
     ]}
 


### PR DESCRIPTION
This fixes a small typo in the documentation of Dream.router.
Dream.param takes the request as first argument, then the request, whereas the doc has reversed the arguments