### PR TITLE
Examples: add w-mlx

### DIFF
--- a/example/w-mlx/README.md
+++ b/example/w-mlx/README.md
@@ -1,0 +1,35 @@
+# `w-mlx`
+
+<br>
+
+[mlx](https://github.com/ocaml-mlx/mlx), an OCaml syntax dialect which adds JSX
+expressions, can be used with Dream for generating HTML. 
+
+```ocaml
+let greet ~who () =
+  <html>
+    <head>
+      <title>"Greeting"</title>
+    </head>
+    <body>
+      <h1>"Good morning, " (JSX.string who) "!"</h1>
+    </body>
+  </html>
+
+let () =
+  Dream.run
+  @@ Dream.logger
+  @@ Dream.router [
+    Dream.get "/" (fun _ ->
+      let html = JSX.render <greet who="world" /> in
+      Dream.html html)
+  ]
+```
+
+<pre><code><b>$ cd example/w-mlx</b>
+<b>$ opam install --deps-only --yes .</b>
+<b>$ dune exec --root . ./mlx.exe</b></code></pre>
+
+<br>
+
+[Up to the example index](../#examples)

--- a/example/w-mlx/dune
+++ b/example/w-mlx/dune
@@ -1,0 +1,4 @@
+(executable
+ (name mlx)
+ (libraries dream html_of_jsx)
+ (preprocess (pps html_of_jsx.ppx)))

--- a/example/w-mlx/dune-project
+++ b/example/w-mlx/dune-project
@@ -1,0 +1,10 @@
+(lang dune 3.16)
+
+(dialect
+ (name mlx)
+ (implementation
+  (merlin_reader mlx)
+  (extension mlx)
+  (preprocess
+   (run mlx-pp %{input-file}))))
+

--- a/example/w-mlx/mlx.mlx
+++ b/example/w-mlx/mlx.mlx
@@ -1,0 +1,18 @@
+let greet ~who () =
+  <html>
+    <head>
+      <title>"Greeting"</title>
+    </head>
+    <body>
+      <h1>"Good morning, " (JSX.string who) "!"</h1>
+    </body>
+  </html>
+
+let () =
+  Dream.run
+  @@ Dream.logger
+  @@ Dream.router [
+    Dream.get "/" (fun _ ->
+      let html = JSX.render <greet who="world" /> in
+      Dream.html html)
+  ]

--- a/example/w-mlx/w-mlx.opam
+++ b/example/w-mlx/w-mlx.opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dream"
+  "dune" {>= "3.16.0"}
+  "mlx"
+  "html_of_jsx"
+]


### PR DESCRIPTION
Adds an example using [mlx](https://github.com/ocaml-mlx/mlx).

mlx is an OCaml dialect which extends regular OCaml syntax with JSX expressions. The dialect features first class support from merlin/lsp.