### PR TITLE
CI: test only on OCaml 4.13 and higher

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,9 @@ jobs:
         - 5.0.x
         - 4.14.x
         - 4.13.x
-        - 4.12.x
-        - 4.11.x
-        - 4.10.x
-        - 4.09.x
-        - 4.08.x
         include:
         - os: macos-latest
-          ocaml: 4.12.x
+          ocaml: 4.14.x
         - os: windows-latest
           ocaml: 4.14.x
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,14 +24,16 @@ jobs:
       with:
         submodules: recursive
 
-    - uses: avsm/setup-ocaml@v2
+    - uses: avsm/setup-ocaml@v3
       if: runner.os != 'Windows'
       with:
+        opam-local-packages: dream-pure.opam dream-httpaf.opam dream.opam
         ocaml-compiler: ${{matrix.ocaml}}
 
-    - uses: avsm/setup-ocaml@v2
+    - uses: avsm/setup-ocaml@v3
       if: runner.os == 'Windows'
       with:
+        opam-local-packages: dream-pure.opam dream-httpaf.opam dream.opam
         ocaml-compiler: ${{matrix.ocaml}}
         opam-repositories: |
           opam-repository-mingw: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset


### PR DESCRIPTION
Dream no longer installs on lower OCaml versions, because mirage-crypto requires OCaml 4.13. See

  https://github.com/mirage/mirage-crypto/pull/233

The reason for mirage-crypto requiring 4.13 seems to be minor convenience, and isn't justified in my opinion. However, Dream itself will likely require OCaml 5 in the medium term due to upgrading to multicore and effects, so it seems unnecessary to make an effort to restore 4.08 support at this point.