### PR TITLE
Properly exit when running in Docker container

### DIFF
--- a/src/http/http.ml
+++ b/src/http/http.ml
@@ -714,16 +714,16 @@ let run
     log "Type Ctrl+C to stop"
   end;
 
-  Lwt_main.run begin
-    serve_with_maybe_https
-      "run"
-      ~interface
-      ~network:(network ~port ~socket_path)
-      ~stop
-      ~error_handler
-      ~tls:(if tls then `OpenSSL else `No)
-      ?certificate_file ?key_file
-      ?certificate_string:None ?key_string:None
-      ~builtins
-      user's_dream_handler
-  end;
+    Lwt_main.run begin
+      serve_with_maybe_https
+        "run"
+        ~interface
+        ~network:(network ~port ~socket_path)
+        ~stop
+        ~error_handler
+        ~tls:(if tls then `OpenSSL else `No)
+        ?certificate_file ?key_file
+        ?certificate_string:None ?key_string:None
+        ~builtins
+        user's_dream_handler
+    end;

--- a/src/http/http.ml
+++ b/src/http/http.ml
@@ -682,16 +682,18 @@ let run
     ?key_file
     ?(builtins = true)
     ?(greeting = true)
-    ?(adjust_terminal = true)
+    ?(adjust_terminal = false)
     user's_dream_handler =
 
   let () = if Sys.unix then
     Sys.(set_signal sigpipe Signal_ignore)
   in
 
-  let _ = adjust_terminal in
-
   let log = Log.convenience_log in
+
+  if adjust_terminal then begin
+      log "The '~adjust_terminal' option is deprecated and will be removed in a future release. Dream no longer truncates long log lines.";
+  end;
 
   if greeting then begin
     let scheme =

--- a/src/http/http.ml
+++ b/src/http/http.ml
@@ -720,8 +720,12 @@ let run
         | Sys.Signal_handle f -> f signal
         | Sys.Signal_ignore -> ignore ()
         | Sys.Signal_default ->
-          Sys.set_signal signal Sys.Signal_default;
-          Unix.kill (Unix.getpid ()) signal)
+          let pid = Unix.getpid () in
+          if pid = 1 then (* we are running in a Docker container *)
+            Unix._exit 0
+          else
+            Sys.set_signal signal Sys.Signal_default;
+            Unix.kill pid signal)
   in
 
   create_handler Sys.sigint;


### PR DESCRIPTION
This adds a special case for handling signals when we are running in a Docker container. If our PID is 1 then we just exit. This solves #174. I'm not entirely sure why the existing approach doesn't work when running in Docker, but I suspect it's got something to do with dream being the PID 1 and then killing itself that Docker doesn't like.

I used this (very bad) Dockerfile to test the implementation:

```dockerfile
FROM ocaml/opam@sha256:c900eb55237d14dd57bc10c2f7f9fb09d8b236bcc9572c9f283c9bddfa096fd3 AS build

# Install system dependencies
RUN sudo apk add --update libev-dev openssl-dev gmp-dev pcre-dev libev-dev pkgconf postgresql14-dev sqlite-dev

# Pull the latest OPAM repository updates
RUN cd ~/opam-repository && git pull origin master && opam update
WORKDIR /dream
COPY Makefile .
COPY dream-httpaf.opam .
COPY dream-mirage.opam .
COPY dream-pure.opam .
COPY dream.opam .
COPY dune-project .
RUN opam install dune
RUN make deps
COPY src .
RUN opam exec -- dune build --only-packages dream-pure,dream-httpaf,dream --no-print-directory @install
COPY example .

ENTRYPOINT ["opam", "exec", "--", "dune", "exec", "./1-hello/hello.exe"]
```