### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,17 +8,11 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        # - macos-latest
+        - macos-latest
+        - windows-latest
         ocaml-compiler:
-          - 5.2.x
-          - 5.1.x
           - 5.0.x
           - 4.14.x
-        # include:
-        # - os: windows-latest
-        #   ocaml: 4.14.x
-        # - os: macos-latest
-        #   ocaml: 4.12.x
 
     runs-on: ${{matrix.os}}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Prepare MacOS
       run: brew install postgresql@15 && brew link --overwrite postgresql@15
-      if: runner.os == "MacOS"
+      if: runner.os == 'macos'
 
     - name: Install deps
       run: make deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,16 +10,16 @@ jobs:
         - ubuntu-latest
         # - macos-latest
         ocaml-compiler:
-          - 5.2.x
+          # - 5.2.x
           - 5.1.x
           - 5.0.x
           - 4.14.x
-          - 4.13.x
-          - 4.12.x
-          - 4.11.x
-          - 4.10.x
-          - 4.09.x
-          - 4.08.x
+          # - 4.13.x
+          # - 4.12.x
+          # - 4.11.x
+          # - 4.10.x
+          # - 4.09.x
+          # - 4.08.x
         # include:
         # - os: windows-latest
         #   ocaml: 4.14.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,7 @@ jobs:
         ocaml-compiler: ${{matrix.ocaml}}
 
     - name: Run quickstart.sh
+      shell: bash
       run: |
         set -x
         touch output

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,6 @@ jobs:
     - name: Run quickstart.sh
       shell: bash
       run: |
-        set -x
         touch output
         tail -f output | grep --line-buffered 'Ctrl' | xargs -L1 -I FOO bash -c "echo Success && touch success && killall middleware.exe" &
         tail -f output &
@@ -111,6 +110,8 @@ jobs:
     - uses: ocaml/setup-ocaml@v3
       with:
         ocaml-compiler: 4.14.x
+    # Needed until https://github.com/robur-coop/ocaml-letsencrypt/pull/34.
+    - run: opam pin add letsencrypt git+https://github.com/hannesm/ocaml-letsencrypt.git#no-cstruct --no-action
     - run: opam install --yes --deps-only ./dream-pure.opam ./dream-httpaf.opam ./dream.opam ./dream-mirage.opam
     - run: opam install --yes mirage mirage-clock-unix
     - run: cd example/w-mirage && mv config.ml config.ml.backup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           - 4.10.x
           - 4.09.x
           - 4.08.x
-        include:
+        # include:
         # - os: windows-latest
         #   ocaml: 4.14.x
         # - os: macos-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,28 +98,28 @@ jobs:
           exit 1
         fi
 
-  # mirage:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #     with:
-  #       submodules: recursive
-  #   - run: mkdir ../repo-copy
-  #   - run: cp -r * ../repo-copy/
-  #   - uses: ocaml/setup-ocaml@v3
-  #     with:
-  #       ocaml-compiler: 4.14.x
-  #   - run: opam install --yes --deps-only ./dream-pure.opam ./dream-httpaf.opam ./dream.opam ./dream-mirage.opam
-  #   - run: opam install --yes mirage mirage-clock-unix
-  #   - run: cd example/w-mirage && mv config.ml config.ml.backup
-  #   - run: cd example/w-mirage && sed -e 's/package "dream-mirage"//' < config.ml.backup > config.ml
-  #   - run: cd example/w-mirage && opam exec -- mirage configure -t unix
-  #   - run: cd example/w-mirage && opam exec -- make depends
-  #   - run: cd example/w-mirage && ls duniverse
-  #   - run: cp -r ../repo-copy example/w-mirage/duniverse/dream
-  #   - run: cd example/w-mirage/duniverse && rm -rf ocaml-cstruct logs ke fmt lwt bytes seq mirage-flow sexplib0 ptime tls domain-name ocaml-ipaddr mirage-clock ocplib-endian
-  #   - run: cd example/w-mirage && mv config.ml.backup config.ml
-  #   - run: cd example/w-mirage && sed -e 's/(libraries/(libraries dream-mirage/' < dune.build > dune.build.2
-  #   - run: cd example/w-mirage && mv dune.build.2 dune.build
-  #   - run: cd example/w-mirage && opam exec -- dune build
-  #   - run: file example/w-mirage/_build/default/main.exe
+  mirage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - run: mkdir ../repo-copy
+    - run: cp -r * ../repo-copy/
+    - uses: ocaml/setup-ocaml@v3
+      with:
+        ocaml-compiler: 4.14.x
+    - run: opam install --yes --deps-only ./dream-pure.opam ./dream-httpaf.opam ./dream.opam ./dream-mirage.opam
+    - run: opam install --yes mirage mirage-clock-unix
+    - run: cd example/w-mirage && mv config.ml config.ml.backup
+    - run: cd example/w-mirage && sed -e 's/package "dream-mirage"//' < config.ml.backup > config.ml
+    - run: cd example/w-mirage && opam exec -- mirage configure -t unix
+    - run: cd example/w-mirage && opam exec -- make depends
+    - run: cd example/w-mirage && ls duniverse
+    - run: cp -r ../repo-copy example/w-mirage/duniverse/dream
+    - run: cd example/w-mirage/duniverse && rm -rf ocaml-cstruct logs ke fmt lwt bytes seq mirage-flow sexplib0 ptime tls domain-name ocaml-ipaddr mirage-clock ocplib-endian
+    - run: cd example/w-mirage && mv config.ml.backup config.ml
+    - run: cd example/w-mirage && sed -e 's/(libraries/(libraries dream-mirage/' < dune.build > dune.build.2
+    - run: cd example/w-mirage && mv dune.build.2 dune.build
+    - run: cd example/w-mirage && opam exec -- dune build
+    - run: file example/w-mirage/_build/default/main.exe

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
     - run: cd example/w-mirage && opam exec -- make depends
     - run: cd example/w-mirage && ls duniverse
     - run: cp -r ../repo-copy example/w-mirage/duniverse/dream
-    - run: cd example/w-mirage/duniverse && rm -rf ocaml-cstruct logs ke fmt lwt bytes seq mirage-flow sexplib0 ptime tls domain-name ocaml-ipaddr mirage-clock ocplib-endian digestif eqaf mirage-crypto
+    - run: cd example/w-mirage/duniverse && rm -rf ocaml-cstruct logs ke fmt lwt bytes seq mirage-flow sexplib0 ptime tls domain-name ocaml-ipaddr mirage-clock ocplib-endian digestif eqaf mirage-crypto mirage-runtime
     - run: cd example/w-mirage && mv config.ml.backup config.ml
     - run: cd example/w-mirage && sed -e 's/(libraries/(libraries dream-mirage/' < dune.build > dune.build.2
     - run: cd example/w-mirage && mv dune.build.2 dune.build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
     #   if: runner.os != 'Windows'
 
     - name: Install dune
-      run: opam install dune
+      run: opam install dune && eval $(opam env)
     - name: Install deps
       run: make deps
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,33 +25,22 @@ jobs:
       with:
         ocaml-compiler: ${{matrix.ocaml-compiler}}
 
-    # - uses: ocaml/setup-ocaml@v3
-    #   if: runner.os == 'Windows'
-    #   with:
-    #     ocaml-compiler: ${{matrix.ocaml}}
-    #     opam-repositories: |
-    #       opam-repository-mingw: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
-    #       default: https://github.com/ocaml/opam-repository.git
 
-    # - run: opam depext --yes conf-sqlite3
-    # - run: opam depext --yes conf-postgresql
-    # - run: opam depext --yes conf-libev
-    #   if: runner.os != 'Windows'
-
+    # For caqti Postgres tests. Opam does actually install Postgres for us, however brew
+    # doesn't link it by default, so we have to install and link it manually.
+    # - name: Prepare MacOS
+    #   run: brew install postgresql@15 && brew link --overwrite postgresql@15
+    #   if: runner.os == 'macOS'
     - name: Prepare MacOS
-      run: brew install postgresql@15 && brew link --overwrite postgresql@15
+      run: brew install libev
       if: runner.os == 'macOS'
 
-    - name: Install deps
-      run: make deps
+    # We don't need Postgres for our tests so we opam to assume it's installed.
+    - name: Install dependencies
+      run: opam install --deps-only --with-test --with-doc --assume-depexts .
 
     - name: Test
       run: eval $(opam env) && make test
-      # run: |
-      #   opam exec -- dune build --no-print-directory --instrument-with bisect_ppx --force @test/runtest
-      #   opam exec -- bisect-ppx-report html
-      #   opam exec -- bisect-ppx-report summary
-      #   echo See _coverage/index.html
 
     # # The tests require ppx_expect. The latest versions of it introduced changes
     # # in the formatting of the output, and also require OCaml >= 4.10, which
@@ -97,36 +86,37 @@ jobs:
     #       done
     #     fi
 
-  # quickstart:
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os:
-  #       - ubuntu-latest
-  #       - macos-latest
-  #
-  #   runs-on: ${{matrix.os}}
-  #   steps:
-  #   - uses: ocaml/setup-ocaml@v3
-  #     name: Use OCaml
-  #     if: runner.os != 'Windows'
-  #     with:
-  #       ocaml-compiler: ${{matrix.ocaml}}
-  #   - name: Quick start
-  #     run: |
-  #       set -x
-  #       touch output
-  #       tail -f output | grep --line-buffered 'Ctrl' | xargs -L1 -I FOO bash -c "echo Success && touch success && killall middleware.exe" &
-  #       tail -f output &
-  #       ((curl -fsSL https://raw.githubusercontent.com/aantron/dream/$GITHUB_SHA/example/quickstart.sh | bash -s $GITHUB_SHA) || true) > output 2>&1
-  #       sleep 1
-  #       if [ -f success ]
-  #       then
-  #         exit 0
-  #       else
-  #         exit 1
-  #       fi
-  #
+  quickstart:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+        - ubuntu-latest
+        - macos-latest
+        ocaml-compiler:
+          - 5.0.x
+          - 4.14.x
+
+    runs-on: ${{matrix.os}}
+    steps:
+    - uses: ocaml/setup-ocaml@v3
+      name: Use OCaml
+      with:
+        ocaml-compiler: ${{matrix.ocaml}}
+    - name: Quick start
+      run: |
+        set -x
+        touch output
+        tail -f output | grep --line-buffered 'Ctrl' | xargs -L1 -I FOO bash -c "echo Success && touch success && killall middleware.exe" &
+        tail -f output &
+        ((curl -fsSL https://raw.githubusercontent.com/aantron/dream/$GITHUB_SHA/example/quickstart.sh | bash -s $GITHUB_SHA) || true) > output 2>&1
+        sleep 1
+        if [ -f success ]
+        then
+          exit 0
+        else
+          exit 1
+        fi
   # mirage:
   #   runs-on: ubuntu-latest
   #   steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,88 +8,97 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        ocaml:
-        - 5.0.x
-        - 4.14.x
-        - 4.13.x
-        - 4.12.x
-        - 4.11.x
-        - 4.10.x
-        - 4.09.x
-        - 4.08.x
+        # - macos-latest
+        ocaml-compiler:
+          - 5.2.x
+          - 5.1.x
+          - 5.0.x
+          - 4.14.x
+          - 4.13.x
+          - 4.12.x
+          - 4.11.x
+          - 4.10.x
+          - 4.09.x
+          - 4.08.x
         include:
-        - os: macos-latest
-          ocaml: 4.12.x
-        - os: windows-latest
-          ocaml: 4.14.x
+        # - os: windows-latest
+        #   ocaml: 4.14.x
+        # - os: macos-latest
+        #   ocaml: 4.12.x
 
     runs-on: ${{matrix.os}}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 
     - uses: ocaml/setup-ocaml@v3
-      if: runner.os != 'Windows'
+      name: Use OCaml ${{matrix.ocaml-compiler}}
       with:
-        ocaml-compiler: ${{matrix.ocaml}}
+        ocaml-compiler: ${{matrix.ocaml-compiler}}
 
-    - uses: ocaml/setup-ocaml@v3
-      if: runner.os == 'Windows'
-      with:
-        ocaml-compiler: ${{matrix.ocaml}}
-        opam-repositories: |
-          opam-repository-mingw: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
-          default: https://github.com/ocaml/opam-repository.git
+    # - uses: ocaml/setup-ocaml@v3
+    #   if: runner.os == 'Windows'
+    #   with:
+    #     ocaml-compiler: ${{matrix.ocaml}}
+    #     opam-repositories: |
+    #       opam-repository-mingw: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
+    #       default: https://github.com/ocaml/opam-repository.git
 
     - run: opam depext --yes conf-sqlite3
     - run: opam depext --yes conf-postgresql
     - run: opam depext --yes conf-libev
       if: runner.os != 'Windows'
 
-    # The tests require ppx_expect. The latest versions of it introduced changes
-    # in the formatting of the output, and also require OCaml >= 4.10, which
-    # makes testing on < 4.10 awkward. So, we skip tests on < 4.10.
-    - shell: bash
-      run: |
-        set -e
-        set -x
+    - name: Install deps
+      run: make deps
 
-        WITH_TEST=--with-test
-        case ${{matrix.ocaml}} in
-          4.09.x) WITH_TEST=;;
-          4.08.x) WITH_TEST=;;
-        esac
+    - name: Test
+      run: make test
 
-        # Tests on Windows are disabled because of a difference in ppx_expect
-        # output. See https://github.com/aantron/dream/pull/282.
-        case ${{runner.os}} in
-          Windows) WITH_TEST=;;
-        esac
-
-        OPAM=$(which opam || true)
-        if [ -z "$OPAM" ]
-        then
-          OPAM=D:\\cygwin\\wrapperbin\\opam.cmd
-        fi
-
-        $OPAM install --yes --deps-only $WITH_TEST ./dream-pure.opam ./dream-httpaf.opam ./dream.opam
-
-        if [ ! -z "$WITH_TEST" ]
-        then
-          $OPAM exec -- dune runtest
-
-          EXAMPLES=$(find example -maxdepth 1 -type d -not -name "w-mirage*" -not -name "r-tyxml" | grep -v "^example/0" | grep -v "^example$" | sort)
-          shopt -s nullglob
-
-          for EXAMPLE in $EXAMPLES
-          do
-            FILE=$(ls $EXAMPLE/*.ml $EXAMPLE/*.re $EXAMPLE/server/*.ml $EXAMPLE/server/*.re)
-            EXE=$(echo $FILE | sed 's/\..*$/.exe/g')
-            echo dune build $EXE
-            $OPAM exec -- dune build $EXE
-          done
-        fi
+    # # The tests require ppx_expect. The latest versions of it introduced changes
+    # # in the formatting of the output, and also require OCaml >= 4.10, which
+    # # makes testing on < 4.10 awkward. So, we skip tests on < 4.10.
+    # - shell: bash
+    #   run: |
+    #     set -e
+    #     set -x
+    #
+    #     WITH_TEST=--with-test
+    #     case ${{matrix.ocaml}} in
+    #       4.09.x) WITH_TEST=;;
+    #       4.08.x) WITH_TEST=;;
+    #     esac
+    #
+    #     # Tests on Windows are disabled because of a difference in ppx_expect
+    #     # output. See https://github.com/aantron/dream/pull/282.
+    #     case ${{runner.os}} in
+    #       Windows) WITH_TEST=;;
+    #     esac
+    #
+    #     OPAM=$(which opam || true)
+    #     if [ -z "$OPAM" ]
+    #     then
+    #       OPAM=D:\\cygwin\\wrapperbin\\opam.cmd
+    #     fi
+    #
+    #     $OPAM install --yes --deps-only $WITH_TEST ./dream-pure.opam ./dream-httpaf.opam ./dream.opam
+    #
+    #     if [ ! -z "$WITH_TEST" ]
+    #     then
+    #       $OPAM exec -- dune runtest
+    #
+    #       EXAMPLES=$(find example -maxdepth 1 -type d -not -name "w-mirage*" -not -name "r-tyxml" | grep -v "^example/0" | grep -v "^example$" | sort)
+    #       shopt -s nullglob
+    #
+    #       for EXAMPLE in $EXAMPLES
+    #       do
+    #         FILE=$(ls $EXAMPLE/*.ml $EXAMPLE/*.re $EXAMPLE/server/*.ml $EXAMPLE/server/*.re)
+    #         EXE=$(echo $FILE | sed 's/\..*$/.exe/g')
+    #         echo dune build $EXE
+    #         $OPAM exec -- dune build $EXE
+    #       done
+    #     fi
 
   quickstart:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,10 @@ jobs:
     # - run: opam depext --yes conf-libev
     #   if: runner.os != 'Windows'
 
+    - name: Prepare MacOS
+      run: brew install postgresql@15 && brew link --overwrite postgresql@15
+      if: runner.os == "MacOS"
+
     - name: Install deps
       run: make deps
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,16 +10,8 @@ jobs:
         - ubuntu-latest
         # - macos-latest
         ocaml-compiler:
-          # - 5.2.x
-          - 5.1.x
-          - 5.0.x
+          - 5.2.x
           - 4.14.x
-          # - 4.13.x
-          # - 4.12.x
-          # - 4.11.x
-          # - 4.10.x
-          # - 4.09.x
-          # - 4.08.x
         # include:
         # - os: windows-latest
         #   ocaml: 4.14.x
@@ -51,7 +43,7 @@ jobs:
     #   if: runner.os != 'Windows'
 
     - name: Install dune
-      run: opam install dune && eval $(opam env)
+      run: opam install dune && eval $(opam env) && dune --version
     - name: Install deps
       run: make deps
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,49 +47,20 @@ jobs:
     - run: opam exec -- make test
       if: runner.os != 'Windows'
 
-    # # The tests require ppx_expect. The latest versions of it introduced changes
-    # # in the formatting of the output, and also require OCaml >= 4.10, which
-    # # makes testing on < 4.10 awkward. So, we skip tests on < 4.10.
-    # - shell: bash
-    #   run: |
-    #     set -e
-    #     set -x
-    #
-    #     WITH_TEST=--with-test
-    #     case ${{matrix.ocaml}} in
-    #       4.09.x) WITH_TEST=;;
-    #       4.08.x) WITH_TEST=;;
-    #     esac
-    #
-    #     # Tests on Windows are disabled because of a difference in ppx_expect
-    #     # output. See https://github.com/aantron/dream/pull/282.
-    #     case ${{runner.os}} in
-    #       Windows) WITH_TEST=;;
-    #     esac
-    #
-    #     OPAM=$(which opam || true)
-    #     if [ -z "$OPAM" ]
-    #     then
-    #       OPAM=D:\\cygwin\\wrapperbin\\opam.cmd
-    #     fi
-    #
-    #     $OPAM install --yes --deps-only $WITH_TEST ./dream-pure.opam ./dream-httpaf.opam ./dream.opam
-    #
-    #     if [ ! -z "$WITH_TEST" ]
-    #     then
-    #       $OPAM exec -- dune runtest
-    #
-    #       EXAMPLES=$(find example -maxdepth 1 -type d -not -name "w-mirage*" -not -name "r-tyxml" | grep -v "^example/0" | grep -v "^example$" | sort)
-    #       shopt -s nullglob
-    #
-    #       for EXAMPLE in $EXAMPLES
-    #       do
-    #         FILE=$(ls $EXAMPLE/*.ml $EXAMPLE/*.re $EXAMPLE/server/*.ml $EXAMPLE/server/*.re)
-    #         EXE=$(echo $FILE | sed 's/\..*$/.exe/g')
-    #         echo dune build $EXE
-    #         $OPAM exec -- dune build $EXE
-    #       done
-    #     fi
+    - name: Build examples
+      if: runner.os != 'Windows'
+      run: |
+        set -e
+        set -x
+          EXAMPLES=$(find example -maxdepth 1 -type d -not -name "w-mirage*" -not -name "r-tyxml" | grep -v "^example/0" | grep -v "^example$" | sort)
+          shopt -s nullglob
+          for EXAMPLE in $EXAMPLES
+          do
+            FILE=$(ls $EXAMPLE/*.ml $EXAMPLE/*.re $EXAMPLE/server/*.ml $EXAMPLE/server/*.re)
+            EXE=$(echo $FILE | sed 's/\..*$/.exe/g')
+            echo dune build $EXE
+            opam exec -- dune build $EXE
+          done
 
   quickstart:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,14 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        ocaml-compiler:
+        ocaml:
         - 5.2.x
         - 4.14.x
         include:
         - os: macos-latest
-          ocaml-compiler: 4.14.x
+          ocaml: 4.14.x
         - os: windows-latest
-          ocaml-compiler: 4.14.x
+          ocaml: 4.14.x
 
     runs-on: ${{matrix.os}}
     steps:
@@ -25,7 +25,7 @@ jobs:
 
     - uses: ocaml/setup-ocaml@v3
       with:
-        ocaml-compiler: ${{matrix.ocaml-compiler}}
+        ocaml-compiler: ${{matrix.ocaml}}
 
     # For caqti Postgres tests. Opam does actually install Postgres for us, however brew
     # doesn't link it by default, so we have to install and link it manually.
@@ -68,20 +68,20 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        ocaml-compiler:
+        ocaml:
         - 5.2.x
         - 4.14.x
         include:
         - os: macos-latest
-          ocaml-compiler: 4.14.x
+          ocaml: 4.14.x
         - os: windows-latest
-          ocaml-compiler: 4.14.x
+          ocaml: 4.14.x
 
     runs-on: ${{matrix.os}}
     steps:
     - uses: ocaml/setup-ocaml@v3
       with:
-        ocaml-compiler: ${{matrix.ocaml-compiler}}
+        ocaml-compiler: ${{matrix.ocaml}}
 
     - name: Run quickstart.sh
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,12 +29,12 @@ jobs:
       with:
         submodules: recursive
 
-    - uses: avsm/setup-ocaml@v2
+    - uses: ocaml/setup-ocaml@v3
       if: runner.os != 'Windows'
       with:
         ocaml-compiler: ${{matrix.ocaml}}
 
-    - uses: avsm/setup-ocaml@v2
+    - uses: ocaml/setup-ocaml@v3
       if: runner.os == 'Windows'
       with:
         ocaml-compiler: ${{matrix.ocaml}}
@@ -126,7 +126,7 @@ jobs:
         submodules: recursive
     - run: mkdir ../repo-copy
     - run: cp -r * ../repo-copy/
-    - uses: avsm/setup-ocaml@v2
+    - uses: ocaml/setup-ocaml@v3
       with:
         ocaml-compiler: 4.14.x
     - run: opam install --yes --deps-only ./dream-pure.opam ./dream-httpaf.opam ./dream.opam ./dream-mirage.opam

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,17 +24,8 @@ jobs:
         submodules: recursive
 
     - uses: ocaml/setup-ocaml@v3
-      if: runner.os != 'Windows'
       with:
         ocaml-compiler: ${{matrix.ocaml-compiler}}
-
-    - uses: ocaml/setup-ocaml@v3
-      if: runner.os == 'Windows'
-      with:
-        ocaml-compiler: ${{matrix.ocaml-compiler}}
-        opam-repositories: |
-          opam-repository-mingw: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
-          default: https://github.com/ocaml/opam-repository.git
 
     # For caqti Postgres tests. Opam does actually install Postgres for us, however brew
     # doesn't link it by default, so we have to install and link it manually.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
         submodules: recursive
 
     - uses: ocaml/setup-ocaml@v3
+      if: runner.os != 'Windows'
       with:
         ocaml-compiler: ${{matrix.ocaml-compiler}}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,12 +43,12 @@ jobs:
     #   if: runner.os != 'Windows'
 
     - name: Install dune
-      run: opam install dune && eval $(opam env) && dune --version
+      run: opam install dune 
     - name: Install deps
       run: make deps
 
     - name: Test
-      run: make test
+      run: eval $(opam env) && make test
 
     # # The tests require ppx_expect. The latest versions of it introduced changes
     # # in the formatting of the output, and also require OCaml >= 4.10, which

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
     - run: cd example/w-mirage && opam exec -- make depends
     - run: cd example/w-mirage && ls duniverse
     - run: cp -r ../repo-copy example/w-mirage/duniverse/dream
-    - run: cd example/w-mirage/duniverse && rm -rf ocaml-cstruct logs ke fmt lwt bytes seq mirage-flow sexplib0 ptime tls domain-name ocaml-ipaddr mirage-clock ocplib-endian
+    - run: cd example/w-mirage/duniverse && rm -rf ocaml-cstruct logs ke fmt lwt bytes seq mirage-flow sexplib0 ptime tls domain-name ocaml-ipaddr mirage-clock ocplib-endian digestif
     - run: cd example/w-mirage && mv config.ml.backup config.ml
     - run: cd example/w-mirage && sed -e 's/(libraries/(libraries dream-mirage/' < dune.build > dune.build.2
     - run: cd example/w-mirage && mv dune.build.2 dune.build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,14 @@ jobs:
       with:
         ocaml-compiler: ${{matrix.ocaml-compiler}}
 
+    - uses: ocaml/setup-ocaml@v3
+      if: runner.os == 'Windows'
+      with:
+        ocaml-compiler: ${{matrix.ocaml-compiler}}
+        opam-repositories: |
+          opam-repository-mingw: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
+          default: https://github.com/ocaml/opam-repository.git
+
     # For caqti Postgres tests. Opam does actually install Postgres for us, however brew
     # doesn't link it by default, so we have to install and link it manually.
     - name: Prepare MacOS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
     - run: cd example/w-mirage && opam exec -- make depends
     - run: cd example/w-mirage && ls duniverse
     - run: cp -r ../repo-copy example/w-mirage/duniverse/dream
-    - run: cd example/w-mirage/duniverse && rm -rf ocaml-cstruct logs ke fmt lwt bytes seq mirage-flow sexplib0 ptime tls domain-name ocaml-ipaddr mirage-clock ocplib-endian digestif eqaf
+    - run: cd example/w-mirage/duniverse && rm -rf ocaml-cstruct logs ke fmt lwt bytes seq mirage-flow sexplib0 ptime tls domain-name ocaml-ipaddr mirage-clock ocplib-endian digestif eqaf mirage-crypto
     - run: cd example/w-mirage && mv config.ml.backup config.ml
     - run: cd example/w-mirage && sed -e 's/(libraries/(libraries dream-mirage/' < dune.build > dune.build.2
     - run: cd example/w-mirage && mv dune.build.2 dune.build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,8 +75,6 @@ jobs:
         include:
         - os: macos-latest
           ocaml: 4.14.x
-        - os: windows-latest
-          ocaml: 4.14.x
 
     runs-on: ${{matrix.os}}
     steps:
@@ -87,6 +85,7 @@ jobs:
     - name: Run quickstart.sh
       shell: bash
       run: |
+        set -x
         touch output
         tail -f output | grep --line-buffered 'Ctrl' | xargs -L1 -I FOO bash -c "echo Success && touch success && killall middleware.exe" &
         tail -f output &

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,11 +45,13 @@ jobs:
     #       opam-repository-mingw: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
     #       default: https://github.com/ocaml/opam-repository.git
 
-    - run: opam depext --yes conf-sqlite3
-    - run: opam depext --yes conf-postgresql
-    - run: opam depext --yes conf-libev
-      if: runner.os != 'Windows'
+    # - run: opam depext --yes conf-sqlite3
+    # - run: opam depext --yes conf-postgresql
+    # - run: opam depext --yes conf-libev
+    #   if: runner.os != 'Windows'
 
+    - name: Install dune
+      run: opam install dune
     - name: Install deps
       run: make deps
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,28 +113,29 @@ jobs:
         else
           exit 1
         fi
-  # mirage:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #     with:
-  #       submodules: recursive
-  #   - run: mkdir ../repo-copy
-  #   - run: cp -r * ../repo-copy/
-  #   - uses: ocaml/setup-ocaml@v3
-  #     with:
-  #       ocaml-compiler: 4.14.x
-  #   - run: opam install --yes --deps-only ./dream-pure.opam ./dream-httpaf.opam ./dream.opam ./dream-mirage.opam
-  #   - run: opam install --yes mirage mirage-clock-unix
-  #   - run: cd example/w-mirage && mv config.ml config.ml.backup
-  #   - run: cd example/w-mirage && sed -e 's/package "dream-mirage"//' < config.ml.backup > config.ml
-  #   - run: cd example/w-mirage && opam exec -- mirage configure -t unix
-  #   - run: cd example/w-mirage && opam exec -- make depends
-  #   - run: cd example/w-mirage && ls duniverse
-  #   - run: cp -r ../repo-copy example/w-mirage/duniverse/dream
-  #   - run: cd example/w-mirage/duniverse && rm -rf ocaml-cstruct logs ke fmt lwt bytes seq mirage-flow sexplib0 ptime tls domain-name ocaml-ipaddr mirage-clock ocplib-endian
-  #   - run: cd example/w-mirage && mv config.ml.backup config.ml
-  #   - run: cd example/w-mirage && sed -e 's/(libraries/(libraries dream-mirage/' < dune.build > dune.build.2
-  #   - run: cd example/w-mirage && mv dune.build.2 dune.build
-  #   - run: cd example/w-mirage && opam exec -- dune build
-  #   - run: file example/w-mirage/_build/default/main.exe
+
+  mirage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - run: mkdir ../repo-copy
+    - run: cp -r * ../repo-copy/
+    - uses: ocaml/setup-ocaml@v3
+      with:
+        ocaml-compiler: 4.14.x
+    - run: opam install --yes --deps-only ./dream-pure.opam ./dream-httpaf.opam ./dream.opam ./dream-mirage.opam
+    - run: opam install --yes mirage mirage-clock-unix
+    - run: cd example/w-mirage && mv config.ml config.ml.backup
+    - run: cd example/w-mirage && sed -e 's/package "dream-mirage"//' < config.ml.backup > config.ml
+    - run: cd example/w-mirage && opam exec -- mirage configure -t unix
+    - run: cd example/w-mirage && opam exec -- make depends
+    - run: cd example/w-mirage && ls duniverse
+    - run: cp -r ../repo-copy example/w-mirage/duniverse/dream
+    - run: cd example/w-mirage/duniverse && rm -rf ocaml-cstruct logs ke fmt lwt bytes seq mirage-flow sexplib0 ptime tls domain-name ocaml-ipaddr mirage-clock ocplib-endian
+    - run: cd example/w-mirage && mv config.ml.backup config.ml
+    - run: cd example/w-mirage && sed -e 's/(libraries/(libraries dream-mirage/' < dune.build > dune.build.2
+    - run: cd example/w-mirage && mv dune.build.2 dune.build
+    - run: cd example/w-mirage && opam exec -- dune build
+    - run: file example/w-mirage/_build/default/main.exe

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,9 @@ jobs:
       with:
         ocaml-compiler: ${{matrix.ocaml}}
 
-    # For caqti Postgres tests. Opam does actually install Postgres for us, however brew
-    # doesn't link it by default, so we have to install and link it manually.
+    # For Caqti PostgreSQL examples. opam does actually install PostgreSQL for
+    # us. However, Homebrew doesn't link it by default, so we have to install
+    # and link it manually.
     - run: brew install postgresql@15 && brew link --overwrite postgresql@15
       if: runner.os == 'macOS'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,11 @@ jobs:
       run: brew install postgresql@15 && brew link --overwrite postgresql@15
       if: runner.os == 'macOS'
 
+    # Workaround https://github.com/savonet/ocaml-ssl/issues/155 and/or
+    # https://github.com/ocaml/setup-ocaml/issues/856.
+    - run: opam pin add ssl 0.6.0 --no-action
+      if: runner.os == 'Windows'
+
     - name: Install dependencies
       run: make deps
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,16 +28,12 @@ jobs:
 
     # For caqti Postgres tests. Opam does actually install Postgres for us, however brew
     # doesn't link it by default, so we have to install and link it manually.
-    # - name: Prepare MacOS
-    #   run: brew install postgresql@15 && brew link --overwrite postgresql@15
-    #   if: runner.os == 'macOS'
     - name: Prepare MacOS
-      run: brew install libev
+      run: brew install postgresql@15 && brew link --overwrite postgresql@15
       if: runner.os == 'macOS'
 
-    # We don't need Postgres for our tests so we opam to assume it's installed.
     - name: Install dependencies
-      run: opam install --deps-only --with-test --with-doc --assume-depexts ./dream-pure.opam ./dream-httpaf.opam ./dream.opam
+      run: make deps
 
     - name: Test
       run: eval $(opam env) && make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
         os:
         - ubuntu-latest
         - macos-latest
-        - windows-latest
+        # - windows-latest
         ocaml-compiler:
           - 5.0.x
           - 4.14.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
     - run: cd example/w-mirage && opam exec -- make depends
     - run: cd example/w-mirage && ls duniverse
     - run: cp -r ../repo-copy example/w-mirage/duniverse/dream
-    - run: cd example/w-mirage/duniverse && rm -rf ocaml-cstruct logs ke fmt lwt bytes seq mirage-flow sexplib0 ptime tls domain-name ocaml-ipaddr mirage-clock ocplib-endian digestif
+    - run: cd example/w-mirage/duniverse && rm -rf ocaml-cstruct logs ke fmt lwt bytes seq mirage-flow sexplib0 ptime tls domain-name ocaml-ipaddr mirage-clock ocplib-endian digestif eqaf
     - run: cd example/w-mirage && mv config.ml.backup config.ml
     - run: cd example/w-mirage && sed -e 's/(libraries/(libraries dream-mirage/' < dune.build > dune.build.2
     - run: cd example/w-mirage && mv dune.build.2 dune.build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,58 +102,58 @@ jobs:
     #       done
     #     fi
 
-  quickstart:
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-        - ubuntu-latest
-        - macos-latest
-
-    runs-on: ${{matrix.os}}
-    steps:
-    - uses: ocaml/setup-ocaml@v3
-      name: Use OCaml
-      if: runner.os != 'Windows'
-      with:
-        ocaml-compiler: ${{matrix.ocaml}}
-    - name: Quick start
-      run: |
-        set -x
-        touch output
-        tail -f output | grep --line-buffered 'Ctrl' | xargs -L1 -I FOO bash -c "echo Success && touch success && killall middleware.exe" &
-        tail -f output &
-        ((curl -fsSL https://raw.githubusercontent.com/aantron/dream/$GITHUB_SHA/example/quickstart.sh | bash -s $GITHUB_SHA) || true) > output 2>&1
-        sleep 1
-        if [ -f success ]
-        then
-          exit 0
-        else
-          exit 1
-        fi
-
-  mirage:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - run: mkdir ../repo-copy
-    - run: cp -r * ../repo-copy/
-    - uses: ocaml/setup-ocaml@v3
-      with:
-        ocaml-compiler: 4.14.x
-    - run: opam install --yes --deps-only ./dream-pure.opam ./dream-httpaf.opam ./dream.opam ./dream-mirage.opam
-    - run: opam install --yes mirage mirage-clock-unix
-    - run: cd example/w-mirage && mv config.ml config.ml.backup
-    - run: cd example/w-mirage && sed -e 's/package "dream-mirage"//' < config.ml.backup > config.ml
-    - run: cd example/w-mirage && opam exec -- mirage configure -t unix
-    - run: cd example/w-mirage && opam exec -- make depends
-    - run: cd example/w-mirage && ls duniverse
-    - run: cp -r ../repo-copy example/w-mirage/duniverse/dream
-    - run: cd example/w-mirage/duniverse && rm -rf ocaml-cstruct logs ke fmt lwt bytes seq mirage-flow sexplib0 ptime tls domain-name ocaml-ipaddr mirage-clock ocplib-endian
-    - run: cd example/w-mirage && mv config.ml.backup config.ml
-    - run: cd example/w-mirage && sed -e 's/(libraries/(libraries dream-mirage/' < dune.build > dune.build.2
-    - run: cd example/w-mirage && mv dune.build.2 dune.build
-    - run: cd example/w-mirage && opam exec -- dune build
-    - run: file example/w-mirage/_build/default/main.exe
+  # quickstart:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os:
+  #       - ubuntu-latest
+  #       - macos-latest
+  #
+  #   runs-on: ${{matrix.os}}
+  #   steps:
+  #   - uses: ocaml/setup-ocaml@v3
+  #     name: Use OCaml
+  #     if: runner.os != 'Windows'
+  #     with:
+  #       ocaml-compiler: ${{matrix.ocaml}}
+  #   - name: Quick start
+  #     run: |
+  #       set -x
+  #       touch output
+  #       tail -f output | grep --line-buffered 'Ctrl' | xargs -L1 -I FOO bash -c "echo Success && touch success && killall middleware.exe" &
+  #       tail -f output &
+  #       ((curl -fsSL https://raw.githubusercontent.com/aantron/dream/$GITHUB_SHA/example/quickstart.sh | bash -s $GITHUB_SHA) || true) > output 2>&1
+  #       sleep 1
+  #       if [ -f success ]
+  #       then
+  #         exit 0
+  #       else
+  #         exit 1
+  #       fi
+  #
+  # mirage:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #     with:
+  #       submodules: recursive
+  #   - run: mkdir ../repo-copy
+  #   - run: cp -r * ../repo-copy/
+  #   - uses: ocaml/setup-ocaml@v3
+  #     with:
+  #       ocaml-compiler: 4.14.x
+  #   - run: opam install --yes --deps-only ./dream-pure.opam ./dream-httpaf.opam ./dream.opam ./dream-mirage.opam
+  #   - run: opam install --yes mirage mirage-clock-unix
+  #   - run: cd example/w-mirage && mv config.ml config.ml.backup
+  #   - run: cd example/w-mirage && sed -e 's/package "dream-mirage"//' < config.ml.backup > config.ml
+  #   - run: cd example/w-mirage && opam exec -- mirage configure -t unix
+  #   - run: cd example/w-mirage && opam exec -- make depends
+  #   - run: cd example/w-mirage && ls duniverse
+  #   - run: cp -r ../repo-copy example/w-mirage/duniverse/dream
+  #   - run: cd example/w-mirage/duniverse && rm -rf ocaml-cstruct logs ke fmt lwt bytes seq mirage-flow sexplib0 ptime tls domain-name ocaml-ipaddr mirage-clock ocplib-endian
+  #   - run: cd example/w-mirage && mv config.ml.backup config.ml
+  #   - run: cd example/w-mirage && sed -e 's/(libraries/(libraries dream-mirage/' < dune.build > dune.build.2
+  #   - run: cd example/w-mirage && mv dune.build.2 dune.build
+  #   - run: cd example/w-mirage && opam exec -- dune build
+  #   - run: file example/w-mirage/_build/default/main.exe

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
     - uses: ocaml/setup-ocaml@v3
       name: Use OCaml ${{matrix.ocaml-compiler}}
       with:
-        ocaml-compiler: ${{matrix.ocaml}}
+        ocaml-compiler: ${{matrix.ocaml-compiler}}
     - name: Quick start
       run: |
         set -x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,7 @@ jobs:
     # Needed until https://github.com/robur-coop/ocaml-letsencrypt/pull/34.
     - run: opam pin add letsencrypt git+https://github.com/hannesm/ocaml-letsencrypt.git#no-cstruct --no-action
     - run: opam install --yes --deps-only ./dream-pure.opam ./dream-httpaf.opam ./dream.opam ./dream-mirage.opam
-    - run: opam install --yes mirage mirage-clock-unix
+    - run: opam install --yes mirage mirage-clock-unix mirage-crypto-rng-mirage
     - run: cd example/w-mirage && mv config.ml config.ml.backup
     - run: cd example/w-mirage && sed -e 's/package "dream-mirage"//' < config.ml.backup > config.ml
     - run: cd example/w-mirage && opam exec -- mirage configure -t unix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,7 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
     - uses: ocaml/setup-ocaml@v3
+      name: Use OCaml
       if: runner.os != 'Windows'
       with:
         ocaml-compiler: ${{matrix.ocaml}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,18 +68,22 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        - macos-latest
         ocaml-compiler:
-          - 5.0.x
-          - 4.14.x
+        - 5.2.x
+        - 4.14.x
+        include:
+        - os: macos-latest
+          ocaml-compiler: 4.14.x
+        - os: windows-latest
+          ocaml-compiler: 4.14.x
 
     runs-on: ${{matrix.os}}
     steps:
     - uses: ocaml/setup-ocaml@v3
-      name: Use OCaml ${{matrix.ocaml-compiler}}
       with:
         ocaml-compiler: ${{matrix.ocaml-compiler}}
-    - name: Quick start
+
+    - name: Run quickstart.sh
       run: |
         set -x
         touch output
@@ -93,6 +97,7 @@ jobs:
         else
           exit 1
         fi
+
   # mirage:
   #   runs-on: ubuntu-latest
   #   steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ubuntu-latest
+        os:
+        - ubuntu-latest
         ocaml-compiler:
-          - 5.2.x
-          - 4.14.x
+        - 5.2.x
+        - 4.14.x
         include:
         - os: macos-latest
           ocaml-compiler: 4.14.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,29 +113,28 @@ jobs:
         else
           exit 1
         fi
-
-  mirage:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-    - run: mkdir ../repo-copy
-    - run: cp -r * ../repo-copy/
-    - uses: ocaml/setup-ocaml@v3
-      with:
-        ocaml-compiler: 4.14.x
-    - run: opam install --yes --deps-only ./dream-pure.opam ./dream-httpaf.opam ./dream.opam ./dream-mirage.opam
-    - run: opam install --yes mirage mirage-clock-unix
-    - run: cd example/w-mirage && mv config.ml config.ml.backup
-    - run: cd example/w-mirage && sed -e 's/package "dream-mirage"//' < config.ml.backup > config.ml
-    - run: cd example/w-mirage && opam exec -- mirage configure -t unix
-    - run: cd example/w-mirage && opam exec -- make depends
-    - run: cd example/w-mirage && ls duniverse
-    - run: cp -r ../repo-copy example/w-mirage/duniverse/dream
-    - run: cd example/w-mirage/duniverse && rm -rf ocaml-cstruct logs ke fmt lwt bytes seq mirage-flow sexplib0 ptime tls domain-name ocaml-ipaddr mirage-clock ocplib-endian
-    - run: cd example/w-mirage && mv config.ml.backup config.ml
-    - run: cd example/w-mirage && sed -e 's/(libraries/(libraries dream-mirage/' < dune.build > dune.build.2
-    - run: cd example/w-mirage && mv dune.build.2 dune.build
-    - run: cd example/w-mirage && opam exec -- dune build
-    - run: file example/w-mirage/_build/default/main.exe
+  # mirage:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #     with:
+  #       submodules: recursive
+  #   - run: mkdir ../repo-copy
+  #   - run: cp -r * ../repo-copy/
+  #   - uses: ocaml/setup-ocaml@v3
+  #     with:
+  #       ocaml-compiler: 4.14.x
+  #   - run: opam install --yes --deps-only ./dream-pure.opam ./dream-httpaf.opam ./dream.opam ./dream-mirage.opam
+  #   - run: opam install --yes mirage mirage-clock-unix
+  #   - run: cd example/w-mirage && mv config.ml config.ml.backup
+  #   - run: cd example/w-mirage && sed -e 's/package "dream-mirage"//' < config.ml.backup > config.ml
+  #   - run: cd example/w-mirage && opam exec -- mirage configure -t unix
+  #   - run: cd example/w-mirage && opam exec -- make depends
+  #   - run: cd example/w-mirage && ls duniverse
+  #   - run: cp -r ../repo-copy example/w-mirage/duniverse/dream
+  #   - run: cd example/w-mirage/duniverse && rm -rf ocaml-cstruct logs ke fmt lwt bytes seq mirage-flow sexplib0 ptime tls domain-name ocaml-ipaddr mirage-clock ocplib-endian
+  #   - run: cd example/w-mirage && mv config.ml.backup config.ml
+  #   - run: cd example/w-mirage && sed -e 's/(libraries/(libraries dream-mirage/' < dune.build > dune.build.2
+  #   - run: cd example/w-mirage && mv dune.build.2 dune.build
+  #   - run: cd example/w-mirage && opam exec -- dune build
+  #   - run: file example/w-mirage/_build/default/main.exe

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
         # - macos-latest
         ocaml-compiler:
           - 5.2.x
+          - 5.1.x
+          - 5.0.x
           - 4.14.x
         # include:
         # - os: windows-latest
@@ -42,13 +44,16 @@ jobs:
     # - run: opam depext --yes conf-libev
     #   if: runner.os != 'Windows'
 
-    - name: Install dune
-      run: opam install dune 
     - name: Install deps
       run: make deps
 
     - name: Test
       run: eval $(opam env) && make test
+      # run: |
+      #   opam exec -- dune build --no-print-directory --instrument-with bisect_ppx --force @test/runtest
+      #   opam exec -- bisect-ppx-report html
+      #   opam exec -- bisect-ppx-report summary
+      #   echo See _coverage/index.html
 
     # # The tests require ppx_expect. The latest versions of it introduced changes
     # # in the formatting of the output, and also require OCaml >= 4.10, which

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,7 @@ jobs:
 
     # For caqti Postgres tests. Opam does actually install Postgres for us, however brew
     # doesn't link it by default, so we have to install and link it manually.
-    - name: Prepare MacOS
-      run: brew install postgresql@15 && brew link --overwrite postgresql@15
+    - run: brew install postgresql@15 && brew link --overwrite postgresql@15
       if: runner.os == 'macOS'
 
     # Workaround https://github.com/savonet/ocaml-ssl/issues/155 and/or
@@ -38,11 +37,10 @@ jobs:
     - run: opam pin add ssl 0.6.0 --no-action
       if: runner.os == 'Windows'
 
-    - name: Install dependencies
-      run: make deps
+    - run: make deps
 
     - name: Test
-      run: eval $(opam env) && make test
+      run: opam exec -- make test
 
     # # The tests require ppx_expect. The latest versions of it introduced changes
     # # in the formatting of the output, and also require OCaml >= 4.10, which

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,8 @@ jobs:
     - name: Quick start
       run: |
         set -x
+        bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)"
+        opam init
         touch output
         tail -f output | grep --line-buffered 'Ctrl' | xargs -L1 -I FOO bash -c "echo Success && touch success && killall middleware.exe" &
         tail -f output &

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Prepare MacOS
       run: brew install postgresql@15 && brew link --overwrite postgresql@15
-      if: runner.os == 'macos'
+      if: runner.os == 'macOS'
 
     - name: Install deps
       run: make deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,13 +6,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-        - ubuntu-latest
-        - macos-latest
-        # - windows-latest
+        os: ubuntu-latest
         ocaml-compiler:
-          - 5.0.x
+          - 5.2.x
           - 4.14.x
+        include:
+        - os: macos-latest
+          ocaml-compiler: 4.14.x
+        - os: windows-latest
+          ocaml-compiler: 4.14.x
 
     runs-on: ${{matrix.os}}
     steps:
@@ -21,10 +23,8 @@ jobs:
         submodules: recursive
 
     - uses: ocaml/setup-ocaml@v3
-      name: Use OCaml ${{matrix.ocaml-compiler}}
       with:
         ocaml-compiler: ${{matrix.ocaml-compiler}}
-
 
     # For caqti Postgres tests. Opam does actually install Postgres for us, however brew
     # doesn't link it by default, so we have to install and link it manually.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,10 +37,15 @@ jobs:
     - run: opam pin add ssl 0.6.0 --no-action
       if: runner.os == 'Windows'
 
-    - run: make deps
+    - run: opam exec -- make deps
 
-    - name: Test
-      run: opam exec -- make test
+    - run: opam exec -- make
+
+    # Tests on Windows are disabled because of a difference in ppx_expect
+    # output. See https://github.com/aantron/dream/pull/282. This difference
+    # remains as of ppx_expect 0.16.
+    - run: opam exec -- make test
+      if: runner.os != 'Windows'
 
     # # The tests require ppx_expect. The latest versions of it introduced changes
     # # in the formatting of the output, and also require OCaml >= 4.10, which

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,7 @@ jobs:
         fi
 
   mirage:
+    if: false
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,11 +101,13 @@ jobs:
 
     runs-on: ${{matrix.os}}
     steps:
+    - uses: ocaml/setup-ocaml@v3
+      if: runner.os != 'Windows'
+      with:
+        ocaml-compiler: ${{matrix.ocaml}}
     - name: Quick start
       run: |
         set -x
-        bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)"
-        opam init
         touch output
         tail -f output | grep --line-buffered 'Ctrl' | xargs -L1 -I FOO bash -c "echo Success && touch success && killall middleware.exe" &
         tail -f output &

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
 
     # We don't need Postgres for our tests so we opam to assume it's installed.
     - name: Install dependencies
-      run: opam install --deps-only --with-test --with-doc --assume-depexts .
+      run: opam install --deps-only --with-test --with-doc --assume-depexts ./dream-pure.opam ./dream-httpaf.opam ./dream.opam
 
     - name: Test
       run: eval $(opam env) && make test
@@ -100,7 +100,7 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
     - uses: ocaml/setup-ocaml@v3
-      name: Use OCaml
+      name: Use OCaml ${{matrix.ocaml-compiler}}
       with:
         ocaml-compiler: ${{matrix.ocaml}}
     - name: Quick start

--- a/dream-mirage.opam
+++ b/dream-mirage.opam
@@ -57,7 +57,7 @@ depends: [
   "duration"
   "emile" {>= "1.1"}
   "ke" {>= "0.4"}  # paf.
-  "letsencrypt" {>= "0.5.0"}
+  "letsencrypt" {>= "0.3.0"}
   "lwt"
   "lwt_ppx" {>= "1.2.2"}
   "mimic" {>= "0.0.5"}

--- a/dream-mirage.opam
+++ b/dream-mirage.opam
@@ -57,7 +57,7 @@ depends: [
   "duration"
   "emile" {>= "1.1"}
   "ke" {>= "0.4"}  # paf.
-  "letsencrypt" {>= "0.3.0"}
+  "letsencrypt" {>= "0.5.0"}
   "lwt"
   "lwt_ppx" {>= "1.2.2"}
   "mimic" {>= "0.0.5"}

--- a/dream.opam
+++ b/dream.opam
@@ -89,7 +89,7 @@ depends: [
   "html_of_jsx" {with-test}
   "js_of_ocaml" {with-test}
   "js_of_ocaml-ppx" {with-test}
-  "ppx_expect" {with-test & >= "v0.15.0"}  # Formatting changes.
+  "ppx_expect" {with-test & >= "v0.15.0" & < "v0.17.0"}  # Breaking changes.
   "ppx_yojson_conv" {with-test}
   "reason" {with-test}
   "tyxml" {with-test & >= "4.5.0"}


### PR DESCRIPTION
This PR fixes the pipeline to enable running tests again on Ubuntu and MacOS on OCaml verions 4.14.x and 5.0.x.

Windows builds require some more special attention. There were some errors during compilation of the ssl dependency. Logs can be found here: https://github.com/maxRN/dream/actions/runs/10508356669/job/29112078780

The Mirage tests are also failing, because of some dependency issues which I didn't have time to investigate further. Logs for those can be found here: https://github.com/maxRN/dream/actions/runs/10521553562/job/29152441822 (the other, non-mirage test failures can be ignored - I was just testing something in this run)