### PR TITLE
Remove unused documentation

### DIFF
--- a/docs/web/postprocess/index.ml
+++ b/docs/web/postprocess/index.ml
@@ -1140,46 +1140,6 @@ let part_replacement = {|
 </pre>
 |}
 
-let upload_event_expected = {|<div class="spec type" id="type-upload_event">
- <a href="#type-upload_event" class="anchor"></a><code><span><span class="keyword">type</span> upload_event</span><span> = </span><span>[ </span></code>
- <table>
-  <tbody>
-   <tr id="type-upload_event.File" class="anchored">
-    <td class="def constructor">
-     <a href="#type-upload_event.File" class="anchor"></a><code><span>| </span></code><code><span>`File <span class="keyword">of</span> string * string</span></code>
-    </td>
-   </tr>
-   <tr id="type-upload_event.Field" class="anchored">
-    <td class="def constructor">
-     <a href="#type-upload_event.Field" class="anchor"></a><code><span>| </span></code><code><span>`Field <span class="keyword">of</span> string * string</span></code>
-    </td>
-   </tr>
-   <tr id="type-upload_event.Done" class="anchored">
-    <td class="def constructor">
-     <a href="#type-upload_event.Done" class="anchor"></a><code><span>| </span></code><code><span>`Done</span></code>
-    </td>
-   </tr>
-   <tr id="type-upload_event.Wrong_content_type" class="anchored">
-    <td class="def constructor">
-     <a href="#type-upload_event.Wrong_content_type" class="anchor"></a><code><span>| </span></code><code><span>`Wrong_content_type</span></code>
-    </td>
-   </tr>
-  </tbody>
- </table>
- <code><span> ]</span></code>
-</div>
-|}
-
-let upload_event_replacement = {|
-<pre><span class="keyword">type</span> upload_event = [
-  | `File <span class="of">of</span> <a href="https://ocaml.org/manual/latest/api/String.html">string</a> * <a href="https://ocaml.org/manual/latest/api/String.html">string</a>
-  | `Field <span class="of">of</span> <a href="https://ocaml.org/manual/latest/api/String.html">string</a> * <a href="https://ocaml.org/manual/latest/api/String.html">string</a>
-  | `Done
-  | `Wrong_content_type
-]
-</pre>
-|}
-
 let csrf_result_expected = {|<div class="spec type" id="type-csrf_result">
  <a href="#type-csrf_result" class="anchor"></a><code><span><span class="keyword">type</span> csrf_result</span><span> = </span><span>[ </span></code>
  <table>

--- a/docs/web/postprocess/index.ml
+++ b/docs/web/postprocess/index.ml
@@ -1657,18 +1657,6 @@ let new_field_replacement = {|
 </pre>
 |}
 
-let new_global_expected = {|<div class="spec value" id="val-new_global">
- <a href="#val-new_global" class="anchor"></a><code><span><span class="keyword">val</span> new_global : <span>?name:string <span class="arrow">-&gt;</span></span> <span>?show_value:<span>(<span><span class="type-var">'a</span> <span class="arrow">-&gt;</span></span> string)</span> <span class="arrow">-&gt;</span></span> <span><span>(<span>unit <span class="arrow">-&gt;</span></span> <span class="type-var">'a</span>)</span> <span class="arrow">-&gt;</span></span> <span><span class="type-var">'a</span> <a href="#type-global">global</a></span></span></code>
-</div>
-|}
-
-let new_global_replacement = {|
-<pre><span class="keyword">val</span> new_global :
-  ?name:<a href="https://ocaml.org/manual/latest/api/String.html">string</a> ->
-  ?show_value:('a -> <a href="https://ocaml.org/manual/latest/api/String.html">string</a>) ->
-    (<a href="https://ocaml.org/manual/latest/api/Unit.html">unit</a> -> 'a) -> 'a <a href="#type-global">global</a>
-|}
-
 let run_expected = {|<div class="spec value" id="val-run">
  <a href="#val-run" class="anchor"></a><code><span><span class="keyword">val</span> run : <span>?interface:string <span class="arrow">-&gt;</span></span> <span>?port:int <span class="arrow">-&gt;</span></span> <span>?socket_path:string <span class="arrow">-&gt;</span></span> <span>?stop:<span>unit <a href="#type-promise">promise</a></span> <span class="arrow">-&gt;</span></span>
 <span>?error_handler:<a href="#type-error_handler">error_handler</a> <span class="arrow">-&gt;</span></span> <span>?tls:bool <span class="arrow">-&gt;</span></span> <span>?certificate_file:string <span class="arrow">-&gt;</span></span> <span>?key_file:string <span class="arrow">-&gt;</span></span>

--- a/docs/web/site/docs.css
+++ b/docs/web/site/docs.css
@@ -434,7 +434,6 @@ p + .odoc-spec {
 #val-origin_referrer_check + .spec-doc li + li,
 #val-form + .spec-doc li + li,
 #type-part + .spec-doc li + li,
-#type-upload_event + .spec-doc li + li,
 #val-upload + .spec-doc li + li,
 #val-static + .spec-doc li + li,
 #val-from_path + .spec-doc li + li {

--- a/example/g-upload/README.md
+++ b/example/g-upload/README.md
@@ -74,7 +74,7 @@ However, this is only good for rare, small uploads, such as user avatars, or for
 prototyping.
 
 For more heavy usage, see
-[`Dream.upload`](https://aantron.github.io/dream/#type-upload_event) for
+[`Dream.upload`](https://aantron.github.io/dream/#val-upload) for
 streaming file uploads.
 
 <br>


### PR DESCRIPTION
This PR removes two parts of unused / superseded documentation `upload_event` and `new_global`.
`upload_event` was changed in commit `018e8e273c5e01e24efefa8e2b2b5a9e4145c7a1`.
`new_global` was replaced by `new_field` I think, in commit `2cb98ad0a6e64d30144a2c6aef65140e6d5589fd`.
