### PR TITLE
CI: make sure build isn't broken by new examples

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         set -e
         set -x
-        EXAMPLES=$(find example -maxdepth 1 -type d -not -name "w-mirage*" -not -name "r-tyxml" | grep -v "^example/0" | grep -v "^example$" | sort)
+        EXAMPLES=$(find example -maxdepth 1 -type d -not -name "w-mirage*" -not -name "r-tyxml" -not -name "w-dream-html" | grep -v "^example/0" | grep -v "^example$" | sort)
         shopt -s nullglob
         for EXAMPLE in $EXAMPLES
         do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,7 @@ jobs:
         shopt -s nullglob
         for EXAMPLE in $EXAMPLES
         do
+          echo /$EXAMPLE/
           FILE=$(ls $EXAMPLE/*.ml $EXAMPLE/*.re $EXAMPLE/server/*.ml $EXAMPLE/server/*.re)
           EXE=$(echo $FILE | sed 's/\..*$/.exe/g')
           echo dune build $EXE

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         set -e
         set -x
-        EXAMPLES=$(find example -maxdepth 1 -type d -not -name "w-mirage*" -not -name "r-tyxml" -not -name "w-dream-html" | grep -v "^example/0" | grep -v "^example$" | sort)
+        EXAMPLES=$(find example -maxdepth 1 -type d -not -name "w-mirage*" -not -name "r-tyxml" | grep -v "^example/0" | grep -v "^example$" | sort)
         shopt -s nullglob
         for EXAMPLE in $EXAMPLES
         do


### PR DESCRIPTION
`w-dream-html` depends on external package dream-html, which, in turn, depends on package dream, which makes it awkward to install dream-html inside Dream's CI. So skip this example.