### PR TITLE
w-template-logic: explain %

### DIFF
--- a/example/w-template-logic/README.md
+++ b/example/w-template-logic/README.md
@@ -11,6 +11,8 @@ imperatively. That means that template fragments evaluate to `unit`, and the
 surrounding OCaml code often needs semicolons. Templates also tend to use
 `List.iter` rather than `List.map`.
 
+The `%` and `<%`/`%>` syntax is documented [in the manual](https://aantron.github.io/dream/#templates).
+
 ```ocaml
 let render_home tasks =
   <html>


### PR DESCRIPTION
Being an OCaml beginner, it personally took me a long time to find the documentation for these two keywords.

I was assuming each example would explain everything that introduced in it, so if that's the idea, then this change helps the invariant hold.