### PR TITLE
update depreciated tup2 to t2 in the tutorial

### DIFF
--- a/example/h-sql/README.md
+++ b/example/h-sql/README.md
@@ -14,7 +14,7 @@ module T = Caqti_type
 let list_comments =
   let query =
     let open Caqti_request.Infix in
-    (T.unit ->* T.(tup2 int string))
+    (T.unit ->* T.(t2 int string))
     "SELECT id, text FROM comment" in
   fun (module Db : DB) ->
     let%lwt comments_or_error = Db.collect_list query () in


### PR DESCRIPTION
line `(T.unit ->* T.(tup2 int string))` is updated to `(T.unit ->* T.(t2 int string))` in [h-sql](https://github.com/aantron/dream/tree/master/example/h-sql) as `T.tup2` is depreciated.