### PR TITLE
Follow the deprecation message of "Mirage_crypto_rng_lwt.initialize"

### DIFF
--- a/dream.opam
+++ b/dream.opam
@@ -69,8 +69,8 @@ depends: [
   "magic-mime"
   "markup" {>= "1.0.2"}
   "mirage-clock" {>= "3.0.0"}  # now_d_ps : unit -> int * int64.
-  "mirage-crypto" {>= "1.0.0"}
-  "mirage-crypto-rng" {>= "1.0.0"}
+  "mirage-crypto" {>= "1.2.0"}
+  "mirage-crypto-rng" {>= "1.2.0"}
   "mirage-crypto-rng-lwt"
   "multipart_form" {>= "0.4.0"}
   "multipart_form-lwt"

--- a/src/dream.ml
+++ b/src/dream.ml
@@ -56,7 +56,7 @@ let now () =
 
 let () =
   Random.initialize (fun () ->
-    Mirage_crypto_rng_lwt.initialize (module Mirage_crypto_rng.Fortuna))
+    Mirage_crypto_rng_unix.use_default ())
 
 module Session =
 struct


### PR DESCRIPTION
I came across the following deprecation error when trying to build `dream` today:

```
▶ make build                                                                                                                           
fatal: No names found, cannot describe anything.                   
File "src/dream.ml", line 59, characters 4-36:                                                                                         
59 |     Mirage_crypto_rng_lwt.initialize (module Mirage_crypto_rng.Fortuna))
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^       
Error (alert deprecated): Mirage_crypto_rng_lwt.initialize                                                                             
Use 'Mirage_crypto_rng_unix.use_default ()' instead.                                                                                   
make: *** [Makefile:5: build] Error 1
```

And these are my installed packages:

```
▶ opam list | grep crypto                                          
mirage-crypto            1.2.0        Simple symmetric cryptography for the modern age
mirage-crypto-ec         1.2.0        Elliptic Curve Cryptography with primitives taken from Fiat
mirage-crypto-pk         1.2.0        Simple public-key cryptography for the modern age
mirage-crypto-rng        1.2.0        A cryptographically secure PRNG
mirage-crypto-rng-lwt    1.2.0        A cryptographically secure PRNG
mirage-crypto-rng-mirage 1.2.0        Entropy collection for a cryptographically secure PRNG
```

I confirmed the deprecation from [mirage-crypto release notes for 1.2.0](https://github.com/mirage/mirage-crypto/commit/1f334ef97e042b3367d54fbe8fbcf03b84841a38).