### PR TITLE
Require an initialization call for "Dream.memory_sessions"

### DIFF
--- a/example/b-session/README.md
+++ b/example/b-session/README.md
@@ -8,7 +8,7 @@ Adding [sessions](https://aantron.github.io/dream/#sessions) is straightforward:
 let () =
   Dream.run
   @@ Dream.logger
-  @@ Dream.memory_sessions
+  @@ Dream.memory_sessions ()
   @@ fun request ->
 
     match Dream.session_field request "user" with
@@ -61,7 +61,8 @@ There are two other session back ends, which are persistent:
 - [`Dream.cookie_sessions`](https://aantron.github.io/dream/#val-cookie_sessions)
   stores session data in encrypted cookies. That is, session data is stored on
   clients, rather than on the server. You can replace `Dream.memory_sessions`
-  with `Dream.cookie_sessions` and it will work right away. However, if you
+  with `Dream.cookie_sessions` and it will work right away (except that
+  `Dream.cookie_sessions` don't require a call with `unit`). However, if you
   want to be able to decrypt sessions set by previous runs of the server, use
   the [`Dream.set_secret`](https://aantron.github.io/dream/#val-set_secret)
   middleware before `Dream.cookie_sessions`. If you don't, the server will be

--- a/example/b-session/session.ml
+++ b/example/b-session/session.ml
@@ -1,7 +1,7 @@
 let () =
   Dream.run
   @@ Dream.logger
-  @@ Dream.memory_sessions
+  @@ Dream.memory_sessions ()
   @@ fun request ->
 
     match Dream.session_field request "user" with

--- a/example/d-form/README.md
+++ b/example/d-form/README.md
@@ -27,7 +27,7 @@ let show_form ?message request =
 let () =
   Dream.run
   @@ Dream.logger
-  @@ Dream.memory_sessions
+  @@ Dream.memory_sessions ()
   @@ Dream.router [
 
     Dream.get  "/"
@@ -113,4 +113,3 @@ the data is not sensitive, so we took a shortcut. See
 <br>
 
 [Up to the tutorial index](../#readme)
-

--- a/example/d-form/form.eml.ml
+++ b/example/d-form/form.eml.ml
@@ -19,7 +19,7 @@ let show_form ?message request =
 let () =
   Dream.run
   @@ Dream.logger
-  @@ Dream.memory_sessions
+  @@ Dream.memory_sessions ()
   @@ Dream.router [
 
     Dream.get  "/"

--- a/example/g-upload/README.md
+++ b/example/g-upload/README.md
@@ -36,7 +36,7 @@ let report files =
 let () =
   Dream.run
   @@ Dream.logger
-  @@ Dream.memory_sessions
+  @@ Dream.memory_sessions ()
   @@ Dream.router [
 
     Dream.get  "/" (fun request ->

--- a/example/g-upload/upload.eml.ml
+++ b/example/g-upload/upload.eml.ml
@@ -26,7 +26,7 @@ let report files =
 let () =
   Dream.run
   @@ Dream.logger
-  @@ Dream.memory_sessions
+  @@ Dream.memory_sessions ()
   @@ Dream.router [
 
     Dream.get  "/" (fun request ->

--- a/example/w-flash/README.md
+++ b/example/w-flash/README.md
@@ -53,7 +53,7 @@ let () =
   Dream.set_log_level "dream.flash" `Debug;
   Dream.run
   @@ Dream.logger
-  @@ Dream.memory_sessions
+  @@ Dream.memory_sessions ()
   @@ Dream.flash
   @@ Dream.router [
 

--- a/example/w-flash/flash.eml.ml
+++ b/example/w-flash/flash.eml.ml
@@ -22,7 +22,7 @@ let () =
   Dream.set_log_level "dream.flash" `Debug;
   Dream.run
   @@ Dream.logger
-  @@ Dream.memory_sessions
+  @@ Dream.memory_sessions ()
   @@ Dream.flash
   @@ Dream.router [
 

--- a/example/w-multipart-dump/multipart_dump.eml.ml
+++ b/example/w-multipart-dump/multipart_dump.eml.ml
@@ -13,7 +13,7 @@ let home request =
 let () =
   Dream.run
   @@ Dream.logger
-  @@ Dream.memory_sessions
+  @@ Dream.memory_sessions ()
   @@ Dream.router [
 
     Dream.get  "/" (fun request ->

--- a/example/w-upload-stream/README.md
+++ b/example/w-upload-stream/README.md
@@ -36,7 +36,7 @@ let report files =
 let () =
   Dream.run
   @@ Dream.logger
-  @@ Dream.memory_sessions
+  @@ Dream.memory_sessions ()
   @@ Dream.router [
 
     Dream.get  "/" (fun request ->

--- a/example/w-upload-stream/upload_stream.eml.ml
+++ b/example/w-upload-stream/upload_stream.eml.ml
@@ -26,7 +26,7 @@ let report files =
 let () =
   Dream.run
   @@ Dream.logger
-  @@ Dream.memory_sessions
+  @@ Dream.memory_sessions ()
   @@ Dream.router [
 
     Dream.get  "/" (fun request ->

--- a/src/dream.mli
+++ b/src/dream.mli
@@ -78,7 +78,7 @@ and route
 
     {[
       Dream.router [
-        Dream.scope "/admin" [Dream.memory_sessions] [
+        Dream.scope "/admin" [Dream.memory_sessions ()] [
           Dream.get "/" admin_handler;
           Dream.get "/logout" admin_logout_handler;
         ];
@@ -1585,9 +1585,10 @@ val invalidate_session : request -> unit promise
 
 (** {2 Back ends} *)
 
-val memory_sessions : ?lifetime:float -> middleware
-(** Stores sessions in server memory. Passes session IDs to clients in cookies.
-    Session data is lost when the server process exits. *)
+val memory_sessions : ?lifetime:float -> unit -> middleware
+(** Stores sessions in server memory and requires initialization before
+    usage. Passes session IDs to clients in cookies. Session data is lost when
+    the server process exits. *)
 
 val cookie_sessions : ?lifetime:float -> middleware
 (** Stores sessions in encrypted cookies. Use {!Dream.set_secret} to be able to

--- a/src/mirage/mirage.mli
+++ b/src/mirage/mirage.mli
@@ -87,7 +87,7 @@ module Make
 
       {[
         Dream.router [
-          Dream.scope "/admin" [Dream.memory_sessions] [
+          Dream.scope "/admin" [Dream.memory_sessions ()] [
             Dream.get "/" admin_handler;
             Dream.get "/logout" admin_logout_handler;
           ];
@@ -1475,9 +1475,10 @@ module Make
 
   (** {2 Back ends} *)
 
-  val memory_sessions : ?lifetime:float -> middleware
-  (** Stores sessions in server memory. Passes session IDs to clients in cookies.
-      Session data is lost when the server process exits. *)
+  val memory_sessions : ?lifetime:float -> unit -> middleware
+  (** Stores sessions in server memory and requires initialization before
+      usage. Passes session IDs to clients in cookies. Session data is lost when
+      the server process exits. *)
 
   val cookie_sessions : ?lifetime:float -> middleware
   (** Stores sessions in encrypted cookies. Pass {!Dream.run} [~secret] to be able

--- a/src/server/session.ml
+++ b/src/server/session.ml
@@ -342,7 +342,12 @@ module Make (Pclock : Mirage_clock.PCLOCK) = struct
   let now () = Ptime.to_float_s (Ptime.v (Pclock.now_d_ps ()))
 
   let memory_sessions ?(lifetime = two_weeks) =
-    middleware (Memory.back_end ~now lifetime)
+    (* "Memory.back_end" returns a record that has a state (a hash table). If we
+       don't provide a way to initialize it before returning the middleware, the
+       state won't be shared among routes in "Dream.scope". *)
+    let back_end = (Memory.back_end ~now lifetime)
+    in
+    fun () -> middleware back_end
 
   let cookie_sessions ?(lifetime = two_weeks) =
     middleware (Cookie.back_end ~now lifetime)

--- a/test/expect/server/router.ml
+++ b/test/expect/server/router.ml
@@ -606,7 +606,7 @@ let%expect_test _ =
             baz
             Response: 200 OK
             100 |}];
-  simulate_and_check (app Dream.memory_sessions "999");
+  simulate_and_check (app (Dream.memory_sessions ()) "999");
   [%expect {|
             Response: 200 OK
             baz


### PR DESCRIPTION
## Context

* We know that `Dream.memory_sessions` doesn't work properly when used with `Dream.scope`.
    * #348 
* There is an open PR trying to address the issue, but it has been inactive since November 10, 2024.
    * #349

## Proposal

This PR proposes adding one additional partial application for `Dream.memory_sessions` to make it possible to initialize its state before getting a handler.

```ocaml
(*==== Example 1 ====*)
let () =
  Dream.run
  @@ Dream.logger
  @@ Dream.memory_sessions ()
  @@ fun request -> ...

(*==== Example 2 ====*)
Dream.router [
  (* Note the partial application with unit. *)
  Dream.scope "/admin" [Dream.memory_sessions ()] [
    Dream.get "/" admin_handler;
    Dream.get "/logout" admin_logout_handler;
  ];
]
```

These changes should make it possible to share the session memory state with multiple routes inside a `Dream.scope`.

## Notes

I tried first to change the function `apply` ([router.ml](https://github.com/aantron/dream/blob/master/src/server/router.ml#L144)) and make it generate a unified handler using `router` and building a `route` directly, but I realized this function wasn't designed for nested calls since it would return a 404 response when the request doesn't match a route.