### PR TITLE
cookie_session: set path to / so router wildcards don't mess up sessions

### DIFF
--- a/src/server/session.ml
+++ b/src/server/session.ml
@@ -4,7 +4,6 @@
    Copyright 2021 Anton Bachin *)
 
 
-
 (* https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html *)
 
 module Message = Dream_pure.Message
@@ -317,7 +316,7 @@ struct
         |> Yojson.Basic.to_string
         |> version_value
       in
-      Cookie.set_cookie response request session_cookie value ~max_age
+      Cookie.set_cookie response request session_cookie value ~max_age ~path:(Some "/")
     end;
     Lwt.return response
 


### PR DESCRIPTION
There is currently a bug (one example is in #307) where the cookie sessions are not persisted when they are set from within a wildcard route. The issue seems to be that `Cookie.set_cookie`, when not given a `path` argument, defaults to using `Router.prefix request`. This means that if you have code like:

```
Dream.scope "/somepath" [
  Dream.get "/**" (fun req -> ... Dream.set_session_field req "foo" "bar"
]
```
The field `"foo"` is lost, since the cookie that is set is scoped to `/somepath`, and is thus not loaded by the session middleware.

A complete reproduction is the following repo:
https://github.com/dbp/dream-session-bug-repro

I'm not sure why the cookies default to the router prefix (perhaps that is a bug), but if that is intended behavior, the included patch fixes this behavior by making the cookie session set the path to be `"/"`, so it does not use a default. 

If the cookie_sessions middleware is intended to be able to work on scoped subsites, then this is not the right fix, but also, if that is the case, then there needs to be a larger restructuring of the code, as there would need to be some way of the code indicating _which_ session the field was being written to. 