### PR TITLE
server logger: use ISO 8601 + RFC 3339 for date format

### DIFF
--- a/src/server/log.ml
+++ b/src/server/log.ml
@@ -162,19 +162,10 @@ let reporter ~now () =
          of rounding 999.5+ to 1000 on output. *)
       let time =
         let unix_time = now () in
-        let time = Option.get (Ptime.of_float_s unix_time) in
-        let fraction =
-          fst (modf unix_time) *. 1000. in
-        let clamped_fraction =
-          if fraction > 999. then 999.
-          else fraction
+        match Ptime.of_float_s unix_time with
+        | None -> failwith "Invalid Unix time"
+        | Some time -> Ptime.to_rfc3339 ~frac_s:3 time
         in
-        let ((y, m, d), ((hh, mm, ss), _tz_offset_s)) =
-          Ptime.to_date_time time in
-        Printf.sprintf "%02i.%02i.%02i %02i:%02i:%02i.%03.0f"
-          d m (y mod 100)
-          hh mm ss clamped_fraction
-      in
 
       (* Format the source name column. It is the right-aligned log source name,
          clipped to the column width. If the source is the default application


### PR DESCRIPTION
Not everyone subscribes to Euro-centric date formats. In ‘computer land’
Unix timestamps and ISO 8601 + RFC 3339 are the standards[^1].

Subjectively, I found the date format at present confusing at a
glance — & I would prefer that ambiguity cleared up for me & all other
users.

Now renders like this on my machine

```
2025-05-17T15:18:00.500-00:00    dream.logger  INFO REQ 1 GET / ::1:37698 fd 6 Mozilla/5.0 (X11; Linux x86_64; rv:138.0) Gecko/20100101 Firefox/138.0
```

This request nets a negative lines by just picking one of Ptime’s 2 output options.

[^2]

[^1]: Asia also likes ISO 8601 + RFC 3339 format & most governments recognize it too
[^2]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.