### PR TITLE
Add post_connect to sql_pool 

### DIFF
--- a/docs/web/postprocess/index.ml
+++ b/docs/web/postprocess/index.ml
@@ -1951,7 +1951,8 @@ let graphiql_expected = {|<div class="spec value" id="val-graphiql">
 |}
 
 let sql_pool_expected = {|<div class="spec value" id="val-sql_pool">
- <a href="#val-sql_pool" class="anchor"></a><code><span><span class="keyword">val</span> sql_pool : <span>?size:int <span class="arrow">-&gt;</span></span> <span>string <span class="arrow">-&gt;</span></span> <a href="#type-middleware">middleware</a></span></code>
+ <a href="#val-sql_pool" class="anchor"></a><code><span><span class="keyword">val</span> sql_pool : <span>?size:int <span class="arrow">-&gt;</span></span>
+<span>?post_connect:<span>(<span><span>(<span class="keyword">module</span> <span class="xref-unresolved">Caqti_lwt</span>.CONNECTION)</span> <span class="arrow">-&gt;</span></span> <span><span><span>(unit,&nbsp;<span class="xref-unresolved">Caqti_error</span>.t)</span> <span class="xref-unresolved">Stdlib</span>.result</span> <a href="#type-promise">promise</a></span>)</span> <span class="arrow">-&gt;</span></span> <span>string <span class="arrow">-&gt;</span></span> <a href="#type-middleware">middleware</a></span></code>
 </div>
 |}
 

--- a/src/dream.mli
+++ b/src/dream.mli
@@ -1752,11 +1752,17 @@ val graphiql : ?default_query:string -> string -> handler
     {{:https://cheatsheetseries.owasp.org/cheatsheets/Database_Security_Cheat_Sheet.html}
     OWASP {i Database Security Cheat Sheet}}. *)
 
-val sql_pool : ?size:int -> string -> middleware
+val sql_pool :
+  ?size:int ->
+  ?post_connect:
+    ((module Caqti_lwt.CONNECTION) -> (unit, Caqti_error.t) result promise) ->
+  string ->
+  middleware
 (** Makes an SQL connection pool available to its inner handler. [?size] is the
     maximum number of concurrent connections that the pool will support. The
     default value is picked by the driver. Note that for SQLite, [?size] is
-    capped to [1]. *)
+    capped to [1]. [post_connect] is an optional callback, which is called for
+    every new connection that is opened to the database. *)
 
 val sql : request -> (Caqti_lwt.connection -> 'a promise) -> 'a promise
 (** Runs the callback with a connection from the SQL pool. See example

--- a/src/dream.mli
+++ b/src/dream.mli
@@ -1754,8 +1754,7 @@ val graphiql : ?default_query:string -> string -> handler
 
 val sql_pool :
   ?size:int ->
-  ?post_connect:
-    ((module Caqti_lwt.CONNECTION) -> (unit, Caqti_error.t) result promise) ->
+  ?post_connect: (Caqti_lwt.connection -> unit promise) ->
   string ->
   middleware
 (** Makes an SQL connection pool available to its inner handler. [?size] is the

--- a/src/sql/sql.ml
+++ b/src/sql/sql.ml
@@ -47,15 +47,14 @@ let sql_pool ?size ?post_connect uri =
       log.warning (fun log -> log ~request
         "Dream.sql_pool: \
         'sqlite' is not a valid scheme; did you mean 'sqlite3'?");
+    let post_connect =
+      match post_connect with
+      | None -> standard_post_connect
+      | Some f -> (fun db -> Lwt.map Result.ok (f db))
+    in
     let pool =
       let pool_config = Caqti_pool_config.create ?max_size:size () in
-      Caqti_lwt_unix.connect_pool ~pool_config ~post_connect:(fun db ->
-        Lwt_result.bind (standard_post_connect db) (fun () ->
-            match post_connect with
-            | Some f -> f db
-            | None -> Lwt_result.return ())
-        )
-        parsed_uri
+      Caqti_lwt_unix.connect_pool ~pool_config ~post_connect parsed_uri
     in
     match pool with
     | Ok pool ->


### PR DESCRIPTION
This is taking over #377, which looks stale. I've addressed @yawaramin 's [comments](https://github.com/camlworks/dream/pull/377#discussion_r3162347913) and changed the logic so Dream's standard post_connect is not called when a user-defined one is provided.

Closes: #377 