### PR TITLE
Document decoded route literals

### DIFF
--- a/src/dream.mli
+++ b/src/dream.mli
@@ -1392,6 +1392,13 @@ val router : route list -> handler
     request's prefix to be extended by it. It is mainly useful for “mounting”
     {!Dream.static} as a subsite.
 
+    Route paths are matched against the decoded request path. In route
+    literals, write decoded characters such as ["/photos/södermalm/"], not the
+    percent-encoded wire form such as ["/photos/s%C3%B6dermalm/"]. The original
+    target, returned by {!Dream.target} and printed by the logger, remains
+    percent-encoded so it can be recorded without interpreting arbitrary client
+    input.
+
     It can also be used as an escape hatch to convert a handler, which may
     include its own router, into a subsite. However, it is better to compose
     sites with routes and {!Dream.scope} rather than opaque handlers and [**],

--- a/test/expect/server/router.ml
+++ b/test/expect/server/router.ml
@@ -225,6 +225,17 @@ let%expect_test _ =
     Response: 200 OK
     foo |}]
 
+let%expect_test _ =
+  show "/photos/s%C3%B6dermalm_pride/" @@ Dream.router [
+    Dream.get "/photos/s%C3%B6dermalm_pride/" (fun _ ->
+      Dream.respond "encoded");
+    Dream.get "/photos/södermalm_pride/" (fun _ ->
+      Dream.respond "decoded");
+  ];
+  [%expect {|
+    Response: 200 OK
+    decoded |}]
+
 (* Router matches long paths, does not match prefixes, etc. *)
 
 let%expect_test _ =


### PR DESCRIPTION
## Summary
- Document that route path literals are matched against decoded request paths.
- Add an expect test showing a percent-encoded request target matches the decoded route literal, while `Dream.target` and logger output can still preserve the original encoded target.

Closes #414.

## Validation
- `git diff --check upstream/master...HEAD`
- `opam exec -- dune runtest test/expect/server` (fails locally because this switch is missing `ppx_expect.config_types`, `ppx_expect`, and `lwt_ppx`)