### PR TITLE
Allow customizing the logger middleware source

### DIFF
--- a/src/dream.mli
+++ b/src/dream.mli
@@ -1793,25 +1793,6 @@ val sql : request -> (Caqti_lwt.connection -> 'a promise) -> 'a promise
     OWASP {i Logging Cheat Sheet}} for a survey of security topics related to
     logging. *)
 
-val logger : middleware
-(** Logs and times requests. Time spent logging is included. See example
-    {{:https://github.com/camlworks/dream/tree/master/example/2-middleware#folders-and-files}
-    [2-middleware]}. *)
-
-val log : ('a, Format.formatter, unit, unit) format4 -> 'a
-(** Formats a message and logs it. Disregard the obfuscated type: the first
-    argument is a format string as described in the standard library modules
-    {{:https://v2.ocaml.org/api/Printf.html#VALfprintf} [Printf]} and
-    {{:https://v2.ocaml.org/api/Format.html#VALfprintf} [Format]}. The rest of
-    the arguments are determined by the format string. See example
-    {{:https://github.com/camlworks/dream/tree/master/example/a-log#folders-and-files}
-    [a-log]}.
-
-    {[
-      Dream.log "Counter is now: %i" counter;
-      Dream.log "Client: %s" (Dream.client request);
-    ]} *)
-
 type ('a, 'b) conditional_log =
   ((?request:request ->
    ('a, Format.formatter, unit, 'b) format4 -> 'a) -> 'b) ->
@@ -1826,6 +1807,36 @@ type log_level = [
   | `Debug
 ]
 (** Log levels, in order from most urgent to least. *)
+
+type sub_log = {
+  error   : 'a. ('a, unit) conditional_log;
+  warning : 'a. ('a, unit) conditional_log;
+  info    : 'a. ('a, unit) conditional_log;
+  debug   : 'a. ('a, unit) conditional_log;
+}
+(** Sub-logs. See {!Dream.val-sub_log} below. *)
+
+val logger : ?log:sub_log -> middleware
+(** Logs and times requests. Time spent logging is included. See example
+    {{:https://github.com/camlworks/dream/tree/master/example/2-middleware#folders-and-files}
+    [2-middleware]}.
+
+    [~log] can be used to choose the sub-log used by this middleware. By
+    default, request logs use the ["dream.logger"] source. *)
+
+val log : ('a, Format.formatter, unit, unit) format4 -> 'a
+(** Formats a message and logs it. Disregard the obfuscated type: the first
+    argument is a format string as described in the standard library modules
+    {{:https://v2.ocaml.org/api/Printf.html#VALfprintf} [Printf]} and
+    {{:https://v2.ocaml.org/api/Format.html#VALfprintf} [Format]}. The rest of
+    the arguments are determined by the format string. See example
+    {{:https://github.com/camlworks/dream/tree/master/example/a-log#folders-and-files}
+    [a-log]}.
+
+    {[
+      Dream.log "Counter is now: %i" counter;
+      Dream.log "Client: %s" (Dream.client request);
+    ]} *)
 
 val error     : ('a, unit) conditional_log
 (** Formats a message and writes it to the log at level [`Error]. The inner
@@ -1848,14 +1859,6 @@ val info      : ('a, unit) conditional_log
 val debug     : ('a, unit) conditional_log
 (** Like {!Dream.val-error}, but for each of the other {{!log_level} log
     levels}. *)
-
-type sub_log = {
-  error   : 'a. ('a, unit) conditional_log;
-  warning : 'a. ('a, unit) conditional_log;
-  info    : 'a. ('a, unit) conditional_log;
-  debug   : 'a. ('a, unit) conditional_log;
-}
-(** Sub-logs. See {!Dream.val-sub_log} right below. *)
 
 val sub_log : ?level:[< log_level] -> string -> sub_log
 (** Creates a new sub-log with the given name. For example,

--- a/src/mirage/mirage.mli
+++ b/src/mirage/mirage.mli
@@ -1524,10 +1524,34 @@ module Make
       OWASP {i Logging Cheat Sheet}} for a survey of security topics related to
       logging. *)
 
-  val logger : middleware
+  type ('a, 'b) conditional_log =
+    ((?request:request -> ('a, Format.formatter, unit, 'b) format4 -> 'a) -> 'b) ->
+    unit
+  (** Loggers. This type is difficult to read — instead, see {!Dream.val-error} for
+      usage. *)
+
+  type log_level =
+    [ `Error
+    | `Warning
+    | `Info
+    | `Debug ]
+  (** Log levels, in order from most urgent to least. *)
+
+  type sub_log = {
+    error : 'a. ('a, unit) conditional_log;
+    warning : 'a. ('a, unit) conditional_log;
+    info : 'a. ('a, unit) conditional_log;
+    debug : 'a. ('a, unit) conditional_log;
+  }
+  (** Sub-logs. See {!Dream.val-sub_log} below. *)
+
+  val logger : ?log:sub_log -> middleware
   (** Logs and times requests. Time spent logging is included. See example
       {{:https://github.com/camlworks/dream/tree/master/example/2-middleware#folders-and-files}
-      [2-middleware]} \[{{:http://dream.as/2-middleware} playground}\]. *)
+      [2-middleware]} \[{{:http://dream.as/2-middleware} playground}\].
+
+      [~log] can be used to choose the sub-log used by this middleware. By
+      default, request logs use the ["dream.logger"] source. *)
 
   val log : ('a, Format.formatter, unit, unit) format4 -> 'a
   (** Formats a message and logs it. Disregard the obfuscated type: the first
@@ -1542,19 +1566,6 @@ module Make
         Dream.log "Counter is now: %i" counter;
         Dream.log "Client: %s" (Dream.client request);
       ]} *)
-
-  type ('a, 'b) conditional_log =
-    ((?request:request -> ('a, Format.formatter, unit, 'b) format4 -> 'a) -> 'b) ->
-    unit
-  (** Loggers. This type is difficult to read — instead, see {!Dream.val-error} for
-      usage. *)
-
-  type log_level =
-    [ `Error
-    | `Warning
-    | `Info
-    | `Debug ]
-  (** Log levels, in order from most urgent to least. *)
 
   val error : ('a, unit) conditional_log
   (** Formats a message and writes it to the log at level [`Error]. The inner
@@ -1578,14 +1589,6 @@ module Make
   val debug : ('a, unit) conditional_log
   (** Like {!Dream.val-error}, but for each of the other {{!log_level} log
       levels}. *)
-
-  type sub_log = {
-    error : 'a. ('a, unit) conditional_log;
-    warning : 'a. ('a, unit) conditional_log;
-    info : 'a. ('a, unit) conditional_log;
-    debug : 'a. ('a, unit) conditional_log;
-  }
-  (** Sub-logs. See {!Dream.val-sub_log} right below. *)
 
   val sub_log : ?level:[< log_level] -> string -> sub_log
   (** Creates a new sub-log with the given name. For example,

--- a/src/server/log.ml
+++ b/src/server/log.ml
@@ -462,7 +462,7 @@ let fd_field : int Message.field =
     end
 
   (* The request logging middleware. *)
-  let logger next_handler request =
+  let logger ?(log = log) next_handler request =
 
     let start = now () in
 

--- a/test/unit/logger.ml
+++ b/test/unit/logger.ml
@@ -1,0 +1,76 @@
+(* This file is part of Dream, released under the MIT license. See LICENSE.md
+   for details, or visit https://github.com/camlworks/dream.
+
+   Copyright 2026 funwithcthulhu *)
+
+
+
+let (-:) name f = Alcotest.test_case name `Quick f
+
+
+
+type counts = {
+  error : int;
+  warning : int;
+  info : int;
+  debug : int;
+}
+
+let counting_log () =
+  let error = ref 0
+  and warning = ref 0
+  and info = ref 0
+  and debug = ref 0 in
+
+  let log = {
+    Dream.error = (fun _ -> incr error);
+    warning = (fun _ -> incr warning);
+    info = (fun _ -> incr info);
+    debug = (fun _ -> incr debug);
+  } in
+
+  let counts () = {
+    error = !error;
+    warning = !warning;
+    info = !info;
+    debug = !debug;
+  } in
+
+  log, counts
+
+let run_logger ?(status = `OK) () =
+  let log, counts = counting_log () in
+  let handler _request = Dream.respond ~status "" in
+  Dream.request ""
+  |> Dream.logger ~log handler
+  |> Lwt_main.run
+  |> ignore;
+  counts ()
+
+
+
+let counts =
+  let pp ppf counts =
+    Format.fprintf ppf
+      "{ error = %i; warning = %i; info = %i; debug = %i }"
+      counts.error counts.warning counts.info counts.debug
+  in
+  Alcotest.testable pp (=)
+
+
+
+let tests = "logger", [
+
+  "custom log records success" -: begin fun () ->
+    run_logger ()
+    |> Alcotest.(check counts) "counts"
+      { error = 0; warning = 0; info = 2; debug = 0 }
+  end;
+
+  "custom log records server error" -: begin fun () ->
+    run_logger ~status:`Internal_Server_Error ()
+    |> Alcotest.(check counts) "counts"
+      { error = 1; warning = 0; info = 1; debug = 0 }
+  end;
+
+]

--- a/test/unit/unit.ml
+++ b/test/unit/unit.ml
@@ -9,4 +9,5 @@ let () =
   Alcotest.run "Dream" [
     Request.tests;
     Headers.tests;
+    Logger.tests;
   ]


### PR DESCRIPTION
## Summary
- Add `?log:Dream.sub_log` to `Dream.logger`, preserving the current `dream.logger` source by default.
- Expose the same optional argument in the Mirage signature.
- Add unit coverage using an in-memory `sub_log` to check which log levels the middleware calls.

Closes #413.

## Validation
- `git diff --cached --check`
- `opam exec -- dune build src/dream.mli`
- `opam exec -- dune runtest test/unit` (blocked locally: this switch is missing `alcotest`)
- `opam exec -- dune build src/dream.cma src/dream.cmxa` (blocked locally: this switch is missing `graphql-lwt`)
- `opam exec -- ocamlformat --inplace ...` (not run: project requires ocamlformat 0.25.1, local switch has 0.29.0)