### PR TITLE
Let debug logs follow initialized log level

### DIFF
--- a/src/server/log.ml
+++ b/src/server/log.ml
@@ -329,20 +329,22 @@ let sub_log ?level:level_ name =
         log ~tags format_and_arguments))
   in
 
-  let level =
-    List.find Option.is_some [
-      Option.map to_logs_level level_;
-      List.assoc_opt name !custom_log_levels;
-      Some !level
-    ] in
+  let source_level =
+    match level_ with
+    | Some level ->
+      let level = to_logs_level level in
+      custom_log_levels :=
+        (name, level)::(List.remove_assoc name !custom_log_levels);
+      Some level
+    | None ->
+      List.assoc_opt name !custom_log_levels
+  in
 
   (* Create the actual Logs source, and then wrap all the interesting
      functions. *)
   let src = Logs.Src.create name in
   let (module Log) = Logs.src_log src in
-  Logs.Src.set_level src level;
-  custom_log_levels :=
-    (name, Option.get level)::(List.remove_assoc name !custom_log_levels);
+  Logs.Src.set_level src source_level;
   sources := (name, src) :: (List.remove_assoc name !sources);
 
   {

--- a/test/unit/log.ml
+++ b/test/unit/log.ml
@@ -1,0 +1,24 @@
+(* This file is part of Dream, released under the MIT license. See LICENSE.md
+   for details, or visit https://github.com/camlworks/dream.
+
+   Copyright 2026 funwithcthulhu *)
+
+
+
+let (-:) name f = Alcotest.test_case name `Quick f
+
+
+
+let tests = "log", [
+
+  "default debug follows initialized level" -: begin fun () ->
+    let called = ref false in
+    Dream.initialize_log ~level:`Debug ();
+    Dream.debug (fun log ->
+      called := true;
+      log "debug");
+    !called
+    |> Alcotest.(check bool) "called" true
+  end;
+
+]

--- a/test/unit/unit.ml
+++ b/test/unit/unit.ml
@@ -9,4 +9,5 @@ let () =
   Alcotest.run "Dream" [
     Request.tests;
     Headers.tests;
+    Log.tests;
   ]


### PR DESCRIPTION
## Summary
- Let sub-logs without an explicit level inherit the global Logs level instead of freezing the current Dream default at source creation time.
- Preserve explicit per-source levels set through `Dream.sub_log ~level` and `Dream.set_log_level`.
- Add a unit test for the `Dream.debug` case from the issue: the default logger is created before `Dream.initialize_log ~level:`Debug ()`, then debug output should be enabled.

Closes #388.

## Validation
- `git diff --cached --check`
- `opam exec -- dune runtest test/unit` (blocked locally: this switch is missing `alcotest`)
- `opam exec -- ocamlformat --check ...` (not run: project requires ocamlformat 0.25.1, local switch has 0.29.0)
- `opam exec -- dune build src/server/log.ml` (timed out locally without a useful compiler diagnostic; stopped the leftover build process and cleared its stale `_build/.lock`)