### PR TITLE
Remove installed packages from Mirage duniverse

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,8 +153,8 @@ jobs:
     - run: cd example/w-mirage && opam exec -- make depends
     - run: cd example/w-mirage && ls duniverse
     - run: cp -r ../repo-copy example/w-mirage/duniverse/dream
-    - run: cd example/w-mirage/duniverse && rm -rf ocaml-cstruct logs fmt lwt bytes seq mirage-flow ptime domain-name ocaml-ipaddr mirage-ptime ocplib-endian digestif eqaf mirage-crypto psq mirage-tcpip duration mirage cmdliner randomconv mirage-mtime mtime lru arp ethernet mirage-net mirage-sleep
+    - run: cd example/w-mirage/duniverse && rm -rf $(OPAMCOLOR=never opam list --installed --short) ocaml-cstruct logs fmt lwt lwt-dllist bytes seq mirage-flow ptime domain-name ocaml-ipaddr mirage-ptime ocplib-endian digestif eqaf ohex mirage-crypto psq mirage-tcpip tcpip duration mirage cmdliner randomconv mirage-mtime mtime lru arp ethernet mirage-net mirage-sleep
     - run: cd example/w-mirage && mv config.ml.backup config.ml
     - run: cd example/w-mirage && sed -i -e 's/(libraries/(libraries dream-mirage/' dune.build
-    - run: cd example/w-mirage && opam exec -- dune build
+    - run: cd example/w-mirage && opam exec -- dune build ./main.exe
     - run: file example/w-mirage/_build/default/main.exe


### PR DESCRIPTION
## Summary
- In the Mirage example CI job, remove duniverse directories whose package names are already installed in the opam switch.
- Force plain `opam list` output so CI color settings do not leak escape codes into `rm` arguments.
- Keep explicit removals for duniverse directory names that do not match opam package names, such as `ocaml-cstruct`, `mirage-tcpip`, and `bytes`.
- Build only the generated Mirage `./main.exe` target instead of the default alias, so vendored tests and examples are not part of this smoke test.

This addresses the duplicate-library failures currently seen in Mirage CI, including `ohex`, `lwt-dllist`, `logs`, `tcpip`, and `bytes`.

## Validation
- `git diff --check`
- Observed failing Mirage logs on #423/#424/#426 showing duplicate libraries from both `duniverse` and `_opam/lib`, plus unrelated vendored test/example aliases being built by the default target.