### PR TITLE
Allow tab-indented EML templates

### DIFF
--- a/src/eml/eml.ml
+++ b/src/eml/eml.ml
@@ -146,8 +146,8 @@ struct
 
   let rec scan_whitespace stream columns =
     match Stream.peek stream with
-    | Some ' ' ->
-      Buffer.add_char lookahead_buffer ' ';
+    | Some ((' ' | '\t') as c) ->
+      Buffer.add_char lookahead_buffer c;
       Stream.junk stream;
       scan_whitespace stream (columns + 1)
     | _ ->

--- a/test/expect/eml/tokens.ml
+++ b/test/expect/eml/tokens.ml
@@ -5,7 +5,7 @@
 
 
 
-let show input =
+let scan input =
   Eml.Location.reset ();
 
   let underlying = Stream.of_string input in
@@ -13,13 +13,28 @@ let show input =
     try Some (Stream.next underlying)
     with _ -> None) in
 
+  Eml.Tokenizer.scan input_stream
+
+let show_with format input =
   try
-    input_stream
-    |> Eml.Tokenizer.scan
+    input
+    |> scan
     |> List.map Eml.Token.show
+    |> List.map format
     |> List.iter print_endline
   with Failure message ->
     print_endline message
+
+let show input =
+  show_with (fun text -> text) input
+
+let escape_tabs text =
+  text
+  |> String.split_on_char '\t'
+  |> String.concat "\\t"
+
+let show_escaped_tabs input =
+  show_with escape_tabs input
 
 let%expect_test _ =
   show "";
@@ -90,6 +105,17 @@ let%expect_test _ =
     Text {|  <html>|}
     Newline
     Text {|  </html>|} |xxx}]
+
+let%expect_test _ =
+  show_escaped_tabs "let foo =\n\t<html>\n\t</html>";
+  [%expect {xxx|
+    (1, 0) Code_block
+    let foo =
+
+    Options , 1
+    Text {|\t<html>|}
+    Newline
+    Text {|\t</html>|} |xxx}]
 
 let%expect_test _ =
   show "let foo =\n  <html>\n  plain";


### PR DESCRIPTION
## Summary
- Treat tabs as leading EML whitespace when detecting the start of template text.
- Add tokenizer coverage for a tab-indented template line.

Fixes #392.

## Validation
- `git diff --check`
- `opam exec -- dune build src/eml/main.exe`
- `opam exec -- dune build src/eml/eml.cma src/eml/eml.cmxa`
- `opam exec -- dune exec src/eml/main.exe -- --stdout <tab-indented temp file>`

Blocked locally:
- `opam exec -- dune runtest test/expect/eml` needs `ppx_expect.config_types` and `ppx_expect`, which are not installed in this switch.
- `opam exec -- ocamlformat --check src/eml/eml.ml test/expect/eml/tokens.ml` needs ocamlformat 0.25.1; this switch has 0.29.0.