### PR TITLE
Fix GraphQL example schema construction

### DIFF
--- a/example/i-graphql/README.md
+++ b/example/i-graphql/README.md
@@ -17,7 +17,7 @@ let hardcoded_users = [
   {id = 2; name = "bob"};
 ]
 
-let user =
+let user () =
   Graphql_lwt.Schema.(obj "user"
     ~fields:[
       field "id"
@@ -30,7 +30,8 @@ let user =
         ~resolve:(fun _info user -> user.name);
     ])
 
-let schema =
+let schema () =
+  let user = user () in
   Graphql_lwt.Schema.(schema [
     field "users"
       ~typ:(non_null (list (non_null user)))
@@ -52,7 +53,7 @@ let () =
   @@ Dream.logger
   @@ Dream.origin_referrer_check
   @@ Dream.router [
-    Dream.any "/graphql" (Dream.graphql Lwt.return schema);
+    Dream.any "/graphql" (Dream.graphql Lwt.return (schema ()));
     Dream.get "/" (Dream.graphiql ~default_query "/graphql");
   ]
 ```

--- a/example/i-graphql/graphql.ml
+++ b/example/i-graphql/graphql.ml
@@ -5,7 +5,7 @@ let hardcoded_users = [
   {id = 2; name = "bob"};
 ]
 
-let user =
+let user () =
   Graphql_lwt.Schema.(obj "user"
     ~fields:[
       field "id"
@@ -18,7 +18,8 @@ let user =
         ~resolve:(fun _info user -> user.name);
     ])
 
-let schema =
+let schema () =
+  let user = user () in
   Graphql_lwt.Schema.(schema [
     field "users"
       ~typ:(non_null (list (non_null user)))
@@ -40,6 +41,6 @@ let () =
   @@ Dream.logger
   @@ Dream.origin_referrer_check
   @@ Dream.router [
-    Dream.any "/graphql" (Dream.graphql Lwt.return schema);
+    Dream.any "/graphql" (Dream.graphql Lwt.return (schema ()));
     Dream.get "/" (Dream.graphiql ~default_query "/graphql");
   ]

--- a/example/r-graphql/README.md
+++ b/example/r-graphql/README.md
@@ -20,7 +20,7 @@ let hardcoded_users = [
   {id: 2, name: "bob"},
 ];
 
-let user =
+let user = () =>
   Graphql_lwt.Schema.(
     obj("user", ~fields=
       [
@@ -35,7 +35,9 @@ let user =
     )
   );
 
-let schema =
+let schema = () => {
+  let user = user();
+
   Graphql_lwt.Schema.(
     schema([
       field(
@@ -54,6 +56,7 @@ let schema =
       }),
     ])
   );
+};
 
 let default_query =
   "{\\n  users {\\n    name\\n    id\\n  }\\n}\\n";
@@ -63,7 +66,7 @@ let () =
   @@ Dream.logger
   @@ Dream.origin_referrer_check
   @@ Dream.router([
-    Dream.any("/graphql", Dream.graphql(Lwt.return, schema)),
+    Dream.any("/graphql", Dream.graphql(Lwt.return, schema())),
     Dream.get("/", Dream.graphiql(~default_query, "/graphql")),
   ]);
 ```

--- a/example/r-graphql/graphql.re
+++ b/example/r-graphql/graphql.re
@@ -8,7 +8,7 @@ let hardcoded_users = [
   {id: 2, name: "bob"},
 ];
 
-let user =
+let user = () =>
   Graphql_lwt.Schema.(
     obj("user", ~fields=
       [
@@ -23,7 +23,9 @@ let user =
     )
   );
 
-let schema =
+let schema = () => {
+  let user = user();
+
   Graphql_lwt.Schema.(
     schema([
       field(
@@ -42,6 +44,7 @@ let schema =
       }),
     ])
   );
+};
 
 let default_query =
   "{\\n  users {\\n    name\\n    id\\n  }\\n}\\n";
@@ -51,6 +54,6 @@ let () =
   @@ Dream.logger
   @@ Dream.origin_referrer_check
   @@ Dream.router([
-    Dream.any("/graphql", Dream.graphql(Lwt.return, schema)),
+    Dream.any("/graphql", Dream.graphql(Lwt.return, schema())),
     Dream.get("/", Dream.graphiql(~default_query, "/graphql")),
   ]);


### PR DESCRIPTION
## Summary
- Build the GraphQL object and schema through functions so the example does not keep weak type variables at top level.
- Apply the same shape to the Reason example and keep both README snippets in sync.

Fixes #373.

## Validation
- `git diff --check`

Blocked locally:
- `opam exec -- dune build example/i-graphql/graphql.exe` needs `graphql-lwt`, which is not installed in this switch.