### PR TITLE
Ignore SIGPIPE when serving

### DIFF
--- a/src/http/http.ml
+++ b/src/http/http.ml
@@ -687,6 +687,10 @@ let on_termination_signal () =
   ignore (Lwt_unix.on_signal Sys.sigint (fun _ -> Lwt.wakeup_later int_resolve ()));
   Lwt.pick [term_promise; int_promise]
 
+let ignore_sigpipe () =
+  if Sys.unix then
+    Sys.(set_signal sigpipe Signal_ignore)
+
 let network ~port ~socket_path =
   match socket_path with
   | None -> `Inet port
@@ -703,6 +707,8 @@ let serve
     ?key_file
     ?(builtins = true)
     user's_dream_handler =
+
+  ignore_sigpipe ();
 
   serve_with_maybe_https
     "serve"
@@ -734,9 +740,7 @@ let run
     ?adjust_terminal
     user's_dream_handler =
 
-  let () = if Sys.unix then
-    Sys.(set_signal sigpipe Signal_ignore)
-  in
+  ignore_sigpipe ();
 
   let log = Log.convenience_log in
 


### PR DESCRIPTION
## Summary
- Share the existing SIGPIPE handling between `Dream.run` and `Dream.serve`.
- Keep the signal change at the public server entry points rather than changing response writing internals.

Fixes #378.

## Validation
- `git diff --check`
- `opam exec -- dune build src/http/http.ml`

Blocked locally:
- `opam exec -- dune build src/dream.cma src/dream.cmxa` needs `graphql-lwt`, which is not installed in this switch.
- `opam exec -- ocamlformat --check src/http/http.ml` needs ocamlformat 0.25.1; this switch has 0.29.0.

I did not add a direct regression test here because the reported behavior depends on process-level `SIGPIPE` handling after a peer closes the socket.