### PR TITLE
Stop requiring Reason for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,15 +71,15 @@ jobs:
       run: |
         set -e
         set -x
-        EXCLUDED_EXAMPLES='w-mirage*|r-tyxml|w-dream-html'
+        EXCLUDED_EXAMPLES='w-mirage*|w-dream-html'
         EXAMPLES=$(find example -maxdepth 1 -type d | grep -Ev $EXCLUDED_EXAMPLES | grep -v "^example/0" | grep -v "^example$" | sort)
         shopt -s nullglob
         for EXAMPLE in $EXAMPLES
         do
+          # Reason examples remain in the tree, but should not add a test
+          # dependency on the Reason compiler.
           FILE=$(find $EXAMPLE -maxdepth 1 -type f -and -path "${EXAMPLE}/*.ml")
-          FILE+=$(find $EXAMPLE -maxdepth 1 -type f -and -path "${EXAMPLE}/*.re")
           FILE+=$(find $EXAMPLE -maxdepth 2 -type f -and -path "${EXAMPLE}/server/*.ml")
-          FILE+=$(find $EXAMPLE -maxdepth 2 -type f -and -path "${EXAMPLE}/server/*.re")
 
           if [[ "$FILE" == "" ]]; then
               continue

--- a/dream.opam
+++ b/dream.opam
@@ -90,7 +90,6 @@ depends: [
   "js_of_ocaml-ppx" {with-test}
   "ppx_expect" {with-test & >= "v0.15.0" & < "v0.17.0"}  # Breaking changes.
   "ppx_yojson_conv" {with-test}
-  "reason" {with-test}
   "tyxml" {with-test & >= "4.5.0"}
   "tyxml-jsx" {with-test}
 ]

--- a/example/dune
+++ b/example/dune
@@ -1,0 +1,13 @@
+; Reason examples are standalone esy projects. Keep them out of the
+; repository-wide Dune build so Dream's test dependencies do not include reason.
+(dirs
+ :standard
+ \ r-fullstack-melange
+   r-graphql
+   r-hello
+   r-html_of_jsx
+   r-template
+   r-template-files
+   r-template-logic
+   r-template-stream
+   r-tyxml)


### PR DESCRIPTION
## Summary

- remove `reason` from Dream's `with-test` dependencies
- keep the standalone `r-*` Reason examples out of the repository-wide Dune build
- make the CI example build select OCaml `.ml` entrypoints only

## Notes

The Reason examples remain in the tree as standalone examples. This only removes the requirement that Dream's test dependency set and repository build compile them.

Relates to #420, specifically the question of forcing tests to compile Reason examples. It does not close the broader OCaml 5.5 / Lwt 6 tracking issue.

## Validation

- `git diff --check`
- `opam lint dream.opam`
- `opam lint --recursive example`
- `opam exec -- dune build --only-packages dream-pure,dream-httpaf,dream @install` still fails locally because this switch is missing normal Dream dependencies, but the output no longer includes `reason`, `refmt`, or `example/r-*` traversal.